### PR TITLE
fix(policy): preserve original DataToVerify bytes on commit

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -17,6 +17,7 @@ import path from "path";
 const _currentFile = typeof __filename !== "undefined" ? __filename : import.meta.url;
 const require = createRequire(_currentFile);
 const { PolicySignRequest } = require("heimdall-tide");
+const { Tools: { TideMemory } } = require("@tideorg/js");
 
 // Resolve directory of this file (works in both CJS bundle and ESM dev)
 const _currentDir = typeof __dirname !== "undefined"
@@ -2448,24 +2449,36 @@ export async function registerRoutes(
           return res.status(404).json({ error: "Policy not found" });
         }
 
-        // Extract the Policy from the PolicySignRequest and store it WITH the VVK signature
+        // Compose the stored policy bytes from the ORIGINAL DataToVerify the ORK signed.
+        // We MUST NOT call policy.toBytes() — it rebuilds section 0 from fields, which
+        // can byte-differ from the original (PolicyParameters Map ordering, enum casing,
+        // length-prefix encoding). Sign #2 verifies the signature against the raw bytes
+        // of section 0, so any drift here breaks "Policy signature could not be verified".
         let policyDataBase64: string | undefined;
         try {
           const request = PolicySignRequest.decode(base64ToBytes(pendingPolicy.policyRequestData));
-          const policy = request.getRequestedPolicy();
 
-          // CRITICAL: Attach the VVK signature to the policy
-          // The client sends this signature after executing the PolicySignRequest against Ork
+          // request.draft.GetValue(0) = policy.toBytes() at the moment the request was created
+          // (no signature attached yet). Its inner section 0 IS the DataToVerify bytes the
+          // ORK saw and signed during Sign #1.
+          const policyBytesNoSig = request.draft.GetValue(0);
+          const policyMem = new TideMemory(policyBytesNoSig.length);
+          policyMem.set(policyBytesNoSig);
+          const dataToVerify = policyMem.GetValue(0);
+
           if (signature) {
             const signatureBytes = base64ToBytes(signature);
-            policy.signature = signatureBytes;
-            log(`Attached VVK signature to policy (${signatureBytes.length} bytes)`);
+            // Stored policyData layout: TideMemory([ DataToVerify, signature ])
+            // — section 0 byte-identical to what the ORK signed, section 1 = the new signature.
+            const composed = TideMemory.CreateFromArray([dataToVerify, signatureBytes]);
+            policyDataBase64 = bytesToBase64(composed);
+            log(`Composed signed policy: dtv=${dataToVerify.length}B sig=${signatureBytes.length}B total=${composed.length}B`);
           } else {
-            log(`Warning: No signature provided for policy commit`);
+            log(`Warning: No signature provided for policy commit — storing policy without signature`);
+            policyDataBase64 = bytesToBase64(policyBytesNoSig);
           }
 
-          const policyBytes = policy.toBytes();
-          policyDataBase64 = bytesToBase64(policyBytes);
+          const policyBytes = base64ToBytes(policyDataBase64);
 
           // Store the committed policy bytes in ssh_policies table
           await policyStorage.upsertPolicy({


### PR DESCRIPTION
## Summary
- Stop re-serializing the policy via `policy.toBytes()` when committing to storage; this rebuilds section 0 from fields and can byte-differ from what the ORK actually signed (PolicyParameters Map order, enum casing, length-prefix encoding).
- Compose stored `policyData = TideMemory([ DataToVerify, signature ])` using the exact bytes from `request.draft` so section 0 is byte-identical to what was signed in Sign #1.

## Why
`PolicyAuthorizationFlow.AuthorizeAsync` on the ORK verifies `Policy.Signature` against the raw bytes of `Policy.DataToVerify` (the input section 0, preserved). When section 0 drifts on round-trip, Sign #2 fails with **"Policy signature could not be verified"** while Sign #1 (Doken:1 flow) still succeeds. This change makes the bytes stored at commit time match the bytes the ORK signed.

## Test plan
- [ ] Commit a fresh SSH policy via Admin Approvals
- [ ] Verify server log shows `Composed signed policy: dtv=<N>B sig=64B total=<M>B`
- [ ] Connect via SSH as a user covered by that policy — confirm both signs (createTideRequest → executeSignRequest) succeed
- [ ] Confirm previous "Policy signature could not be verified" errors no longer appear in ORK logs