### PR TITLE
debug(policy): add SHA-256 trace logs at sign / use / attach

### DIFF
--- a/client/src/lib/tideSsh.ts
+++ b/client/src/lib/tideSsh.ts
@@ -130,6 +130,21 @@ export function createTideSshSigner(): SSHSigner {
 
     // Add the policy if we fetched one (for contract validation in the request model)
     if (policyBytes) {
+      // Trace the policy bytes EXACTLY as fetched — section 0 (DataToVerify) hash should
+      // match the [PolicyTrace SIGN] dtv_sha logged at commit time on the server.
+      const sha256Hex = async (buf: Uint8Array) =>
+        Array.from(new Uint8Array(await crypto.subtle.digest("SHA-256", buf as BufferSource)))
+          .map(b => b.toString(16).padStart(2, "0")).join("");
+      const policyMem = new Tools.TideMemory(policyBytes.length);
+      policyMem.set(policyBytes);
+      const dtvBytes = policyMem.GetValue(0);
+      const sigBytes = policyMem.GetValue(1);
+      const [totalSha, dtvSha, sigSha] = await Promise.all([
+        sha256Hex(policyBytes),
+        sha256Hex(dtvBytes),
+        sigBytes && sigBytes.length > 0 ? sha256Hex(sigBytes) : Promise.resolve("(none)"),
+      ]);
+      console.log(`[PolicyTrace ATTACH] role=ssh:${req.username} dtv_len=${dtvBytes.length} dtv_sha=${dtvSha} sig_len=${sigBytes?.length ?? 0} sig_sha=${sigSha} total_len=${policyBytes.length} total_sha=${totalSha}`);
       tideRequest.addPolicy(policyBytes);
       console.log(`[TideSsh] Added policy (${policyBytes.length} bytes)`);
     }
@@ -141,6 +156,7 @@ export function createTideSshSigner(): SSHSigner {
     const initializedRequestBytes = await tc.createTideRequest(tideRequest.encode());
 
     console.log(`[TideSsh] Executing sign request...`);
+    console.log(initializedRequestBytes)
     const sigs: Uint8Array[] = await tc.executeSignRequest(initializedRequestBytes, true);
 
     const sig = sigs?.[0];

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2472,7 +2472,10 @@ export async function registerRoutes(
             // — section 0 byte-identical to what the ORK signed, section 1 = the new signature.
             const composed = TideMemory.CreateFromArray([dataToVerify, signatureBytes]);
             policyDataBase64 = bytesToBase64(composed);
-            log(`Composed signed policy: dtv=${dataToVerify.length}B sig=${signatureBytes.length}B total=${composed.length}B`);
+            const dtvSha = createHash("sha256").update(dataToVerify).digest("hex");
+            const sigSha = createHash("sha256").update(signatureBytes).digest("hex");
+            const composedSha = createHash("sha256").update(composed).digest("hex");
+            log(`[PolicyTrace SIGN] role=${pendingPolicy.roleId} dtv_len=${dataToVerify.length} dtv_sha=${dtvSha} sig_len=${signatureBytes.length} sig_sha=${sigSha} composed_len=${composed.length} composed_sha=${composedSha}`);
           } else {
             log(`Warning: No signature provided for policy commit — storing policy without signature`);
             policyDataBase64 = bytesToBase64(policyBytesNoSig);
@@ -2697,6 +2700,21 @@ export async function registerRoutes(
         }
 
         log(`[PolicyMatch] Found policy for roleId: ${roleId}`);
+
+        // Log section 0 (DataToVerify) hash so we can compare against SIGN-time hash
+        try {
+          const policyBytes = base64ToBytes(policy.policyData);
+          const policyMem = new TideMemory(policyBytes.length);
+          policyMem.set(policyBytes);
+          const dtvBytes = policyMem.GetValue(0);
+          const sigBytes = policyMem.GetValue(1);
+          const dtvSha = createHash("sha256").update(dtvBytes).digest("hex");
+          const sigSha = sigBytes && sigBytes.length > 0 ? createHash("sha256").update(sigBytes).digest("hex") : "(none)";
+          const totalSha = createHash("sha256").update(policyBytes).digest("hex");
+          log(`[PolicyTrace USE] role=${roleId} dtv_len=${dtvBytes.length} dtv_sha=${dtvSha} sig_len=${sigBytes?.length ?? 0} sig_sha=${sigSha} total_len=${policyBytes.length} total_sha=${totalSha}`);
+        } catch (traceError) {
+          log(`[PolicyTrace USE] role=${roleId} — failed to parse stored bytes: ${traceError}`);
+        }
 
         res.json({
           roleId: policy.roleId,


### PR DESCRIPTION
## Summary
Adds three matching trace log lines so we can compare the policy bytes byte-for-byte across the sign → store → use → attach hops, to pin down where (if anywhere) the bytes are diverging when Sign #2 still fails with "Policy signature could not be verified".

| Tag | Where | What it logs |
|---|---|---|
| `[PolicyTrace SIGN]` | `server/routes.ts` (commit endpoint) | DataToVerify / signature / composed-policy lengths and SHA-256s when the ssh_policies row is written |
| `[PolicyTrace USE]` | `server/routes.ts` (getForSshUser endpoint) | Section-0 and section-1 hashes of the bytes the server ships back to the client |
| `[PolicyTrace ATTACH]` | `client/src/lib/tideSsh.ts` (just before `addPolicy()`) | Hashes of the policy as the client parses it, immediately before it goes into the BasicCustomRequest |

## How to read the logs
- If `dtv_sha` is identical at SIGN, USE, and ATTACH → bytes are intact end-to-end. The failure lives downstream (heimdall iframe, BasicCustomRequest re-encoding, or ORK side).
- If any of the three `dtv_sha` values differs from SIGN, the corruption is at that hop.

## Test plan
- [ ] Deploy keylessh server + frontend
- [ ] Commit a fresh SSH policy via Admin Approvals — confirm `[PolicyTrace SIGN]` line in server log
- [ ] Open SSH connect for the same user — confirm `[PolicyTrace USE]` line in server log AND `[PolicyTrace ATTACH]` line in browser console
- [ ] Compare the three `dtv_sha` values — should be byte-identical

Pure-logging change, no behavior impact.