### PR TITLE
fix(ssh-policy): look up policy by gateway-qualified role

### DIFF
--- a/client/src/lib/sshClient.ts
+++ b/client/src/lib/sshClient.ts
@@ -161,6 +161,11 @@ export type SSHSignatureRequest = {
   publicKey?: Uint8Array;
   username: string;
   serverId: string;
+  /**
+   * Gateway through which this SSH connection is being made. Required for resolving
+   * the gateway-qualified policy role (`ssh:<gatewayId>:<serverId>:<username>`).
+   */
+  gatewayId?: string;
 };
 
 export type SSHSigner = (req: SSHSignatureRequest) => Promise<Uint8Array>;
@@ -558,6 +563,7 @@ export class BrowserSSHClient {
                   publicKey: publicKey ? new Uint8Array(publicKey) : undefined,
                   username: this.options.username,
                   serverId: this.options.serverId,
+                  gatewayId: this.options.gatewayId,
                 });
                 return Buffer.from(sig);
               }),

--- a/client/src/lib/tideSsh.ts
+++ b/client/src/lib/tideSsh.ts
@@ -82,22 +82,31 @@ export function createTideSshSigner(): SSHSigner {
       throw new Error("Tide signing APIs are not available (createTideRequest/executeSignRequest)");
     }
 
-    // Fetch the committed policy for this SSH user
-    // Policy is matched by role: ssh:<username>
+    // Fetch the committed policy by its fully-qualified role:
+    //   ssh:<gatewayId>:<serverId>:<sshUser>
+    // This must match the role ID that was used at commit time (which itself comes from
+    // the JWT's resource_access roles, e.g. "ssh:Tide-GW:My Server:demo").
+    const roleId = req.gatewayId && req.serverId
+      ? `ssh:${req.gatewayId}:${req.serverId}:${req.username}`
+      : null;
     let policyBytes: Uint8Array | null = null;
-    console.log(`[TideSsh] Fetching policy for SSH user '${req.username}' (role: ssh:${req.username})`);
-    try {
-      const policyResult = await api.sshPolicies.getForSshUser(req.username);
-      console.log(`[TideSsh] API response:`, policyResult);
-      if (policyResult.policyData) {
-        policyBytes = base64ToBytes(policyResult.policyData);
-        console.log(`[TideSsh] Decoded policy bytes: ${policyBytes.length} bytes`);
-      } else {
-        console.warn(`[TideSsh] API returned no policyData for user '${req.username}'`);
+    if (roleId) {
+      console.log(`[TideSsh] Fetching policy for role '${roleId}'`);
+      try {
+        const policyResult = await api.sshPolicies.getByRole(roleId);
+        console.log(`[TideSsh] API response:`, policyResult);
+        if (policyResult.policyData) {
+          policyBytes = base64ToBytes(policyResult.policyData);
+          console.log(`[TideSsh] Decoded policy bytes: ${policyBytes.length} bytes`);
+        } else {
+          console.warn(`[TideSsh] API returned no policyData for role '${roleId}'`);
+        }
+      } catch (err) {
+        console.error(`[TideSsh] Failed to fetch committed policy for role '${roleId}':`, err);
+        // Continue without policy - Ork will reject if policy is required
       }
-    } catch (err) {
-      console.error(`[TideSsh] Failed to fetch committed policy for SSH user '${req.username}':`, err);
-      // Continue without policy - Ork will reject if policy is required
+    } else {
+      console.warn(`[TideSsh] Skipping policy fetch — missing gatewayId or serverId (gatewayId=${req.gatewayId}, serverId=${req.serverId})`);
     }
 
     // New pattern: BasicCustom<SSH>:BasicCustom<1>
@@ -144,7 +153,7 @@ export function createTideSshSigner(): SSHSigner {
         sha256Hex(dtvBytes),
         sigBytes && sigBytes.length > 0 ? sha256Hex(sigBytes) : Promise.resolve("(none)"),
       ]);
-      console.log(`[PolicyTrace ATTACH] role=ssh:${req.username} dtv_len=${dtvBytes.length} dtv_sha=${dtvSha} sig_len=${sigBytes?.length ?? 0} sig_sha=${sigSha} total_len=${policyBytes.length} total_sha=${totalSha}`);
+      console.log(`[PolicyTrace ATTACH] role=${roleId} dtv_len=${dtvBytes.length} dtv_sha=${dtvSha} sig_len=${sigBytes?.length ?? 0} sig_sha=${sigSha} total_len=${policyBytes.length} total_sha=${totalSha}`);
       tideRequest.addPolicy(policyBytes);
       console.log(`[TideSsh] Added policy (${policyBytes.length} bytes)`);
     }
@@ -187,18 +196,25 @@ export function createDynamicTideSshSigner(): SSHSigner {
       throw new Error("Tide signing APIs are not available (createTideRequest/executeSignRequest)");
     }
 
-    // Fetch the committed policy for this SSH user
-    // Policy is matched by role: ssh:<username>
+    // Fetch the committed policy by its fully-qualified role:
+    //   ssh:<gatewayId>:<serverId>:<sshUser>
+    const roleId = req.gatewayId && req.serverId
+      ? `ssh:${req.gatewayId}:${req.serverId}:${req.username}`
+      : null;
     let policyBytes: Uint8Array | null = null;
-    try {
-      const policyResult = await api.sshPolicies.getForSshUser(req.username);
-      if (policyResult.policyData) {
-        policyBytes = base64ToBytes(policyResult.policyData);
-        console.log(`[TideSsh] Fetched policy for SSH user '${req.username}' (role: ${policyResult.roleId}), ${policyBytes.length} bytes`);
+    if (roleId) {
+      try {
+        const policyResult = await api.sshPolicies.getByRole(roleId);
+        if (policyResult.policyData) {
+          policyBytes = base64ToBytes(policyResult.policyData);
+          console.log(`[TideSsh] Fetched policy for role '${roleId}', ${policyBytes.length} bytes`);
+        }
+      } catch (err) {
+        console.warn(`[TideSsh] Failed to fetch committed policy for role '${roleId}':`, err);
+        // Continue without policy - Ork will reject if policy is required
       }
-    } catch (err) {
-      console.warn(`[TideSsh] Failed to fetch committed policy for SSH user '${req.username}':`, err);
-      // Continue without policy - Ork will reject if policy is required
+    } else {
+      console.warn(`[TideSsh] Skipping policy fetch — missing gatewayId or serverId`);
     }
 
     // DynamicCustom pattern: data to sign is in DynamicData


### PR DESCRIPTION
## Summary
Committed SSH policies are written under the JWT's gateway-qualified role (`ssh:<gatewayId>:<serverId>:<sshUser>`, e.g. `ssh:Tide-GW:My Server:demo`), but the SSH connect path was fetching by the short-form `ssh:<user>` (e.g. `ssh:demo`). The lookup either 404'd or returned a stale row from an older code revision, which then failed Sign #2 with "Policy signature could not be verified" because the bytes the ORK saw were never associated with the freshly-committed signature.

## What changed
- **`client/src/lib/sshClient.ts`** — `SSHSignatureRequest` gains `gatewayId?: string`; the `DelegatingPublicKeyAlgorithm` callback forwards `this.options.gatewayId` into the signer.
- **`client/src/lib/tideSsh.ts`** — both `createTideSshSigner` and `createDynamicTideSshSigner` now build the gateway-qualified role and fetch via `api.sshPolicies.getByRole(roleId)` (existing endpoint with exact lookup). Non-gateway flows (missing `gatewayId`/`serverId`) skip policy fetch with a warning instead of crashing.

No server-side changes — the existing `GET /api/ssh-policies/committed/:roleId` endpoint already does exact role lookup, which is what we need.

## Verification via the trace logs from #41
Before this fix:
```
[PolicyTrace SIGN]   role=ssh:Tide-GW:My Server:demo dtv_sha=793dc9e7…
[PolicyTrace USE]    role=ssh:demo                   dtv_sha=d2946e66…   ← different row
[PolicyTrace ATTACH] role=ssh:demo                   dtv_sha=d2946e66…
```

After this fix, all three should carry the same role and identical `dtv_sha`.

## Pre-deploy: delete the orphan row
The pre-fix code-path may have left an `ssh:<user>` row in `ssh_policies` that no longer corresponds to a real JWT role:
```sql
DELETE FROM ssh_policies WHERE role_id NOT LIKE 'ssh:%:%:%';
```

## Test plan
- [ ] Deploy keylessh web app
- [ ] Delete stale short-form `ssh_policies` rows (optional cleanup)
- [ ] Commit an SSH policy via Admin Approvals — confirm `[PolicyTrace SIGN]` with gateway-qualified role
- [ ] Connect SSH to that server as the relevant user — confirm `[PolicyTrace USE]` and `[PolicyTrace ATTACH]` carry the *same* role and *same* `dtv_sha` as SIGN
- [ ] SSH session succeeds (no "Policy signature could not be verified")