### PR TITLE
fix(api): preserve raw colons in role-ID path segment (DPoP htu mismatch)

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -94,9 +94,17 @@ export const api = {
 
     /**
      * Gets the committed policy for a specific role.
+     *
+     * NOTE: role IDs contain `:` (e.g. ssh:Tide-GW:My Server:demo). RFC 3986 allows `:`
+     * in path segments as `pchar`, and the DPoP `htu` canonicalization on this server
+     * keeps colons raw. encodeURIComponent would encode them as %3A, which makes the
+     * server-computed htu diverge from what the DPoP proof signed and yields a 401
+     * with "htu mismatch". So we encode everything else, then restore the colons.
      */
     getByRole: (roleId: string) =>
-      apiRequest<CommittedPolicyResult>(`/api/ssh-policies/committed/${encodeURIComponent(roleId)}`),
+      apiRequest<CommittedPolicyResult>(
+        `/api/ssh-policies/committed/${encodeURIComponent(roleId).replace(/%3A/g, ":")}`,
+      ),
   },
   ssh: {
     getAccessStatus: async () => {


### PR DESCRIPTION
## Summary
After #42 the SSH connect path correctly builds `ssh:<gw>:<srv>:<user>` role IDs and fetches via `getByRole(...)`, but the request now fails with **401 "DPoP proof invalid: htu mismatch"**:

```
got      = https://demo.keylessh.com/api/ssh-policies/committed/ssh%3ATide-GW%3AMy%20Server%3Ademo
expected = https://demo.keylessh.com/api/ssh-policies/committed/ssh:Tide-GW:My%20Server:demo
```

`encodeURIComponent` encodes `:` as `%3A`, but the DPoP `htu` canonicalization on this server keeps colons raw. The wire URL contains `%3A` while the signed `htu` claim contains `:` → server rejects with 401 before our route ever runs.

RFC 3986 permits `:` in path segments as `pchar`. Restoring raw colons after `encodeURIComponent` is safe and makes the wire URL match what DPoP canonicalizes to.

## Change
`client/src/lib/api.ts` — `getByRole`:
```ts
// Before:
`/api/ssh-policies/committed/${encodeURIComponent(roleId)}`
// After:
`/api/ssh-policies/committed/${encodeURIComponent(roleId).replace(/%3A/g, ":")}`
```

Only one call site uses this URL pattern with a role-ID containing `:`; audited via grep.

## Test plan
- [ ] Deploy keylessh web app
- [ ] Connect SSH via gateway-mode (role `ssh:Tide-GW:My Server:demo`)
- [ ] Confirm no `401 (Unauthorized)` / no "htu mismatch" in browser console
- [ ] Confirm `[PolicyTrace USE]` and `[PolicyTrace ATTACH]` from #41 now appear and carry matching `dtv_sha`