### PR TITLE
debug(policy): emit [PolicyTrace USE] from /committed/:roleId endpoint

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2661,6 +2661,21 @@ export async function registerRoutes(
           return res.status(404).json({ error: "Policy exists but has no committed policy data" });
         }
 
+        // Log section 0 (DataToVerify) hash so we can compare against SIGN-time hash
+        try {
+          const policyBytes = base64ToBytes(policy.policyData);
+          const policyMem = new TideMemory(policyBytes.length);
+          policyMem.set(policyBytes);
+          const dtvBytes = policyMem.GetValue(0);
+          const sigBytes = policyMem.GetValue(1);
+          const dtvSha = createHash("sha256").update(dtvBytes).digest("hex");
+          const sigSha = sigBytes && sigBytes.length > 0 ? createHash("sha256").update(sigBytes).digest("hex") : "(none)";
+          const totalSha = createHash("sha256").update(policyBytes).digest("hex");
+          log(`[PolicyTrace USE] role=${policy.roleId} dtv_len=${dtvBytes.length} dtv_sha=${dtvSha} sig_len=${sigBytes?.length ?? 0} sig_sha=${sigSha} total_len=${policyBytes.length} total_sha=${totalSha}`);
+        } catch (traceError) {
+          log(`[PolicyTrace USE] role=${policy.roleId} — failed to parse stored bytes: ${traceError}`);
+        }
+
         res.json({
           roleId: policy.roleId,
           policyData: policy.policyData,


### PR DESCRIPTION
## Summary
After PR #42 the SSH connect path fetches via the gateway-qualified `/api/ssh-policies/committed/:roleId` endpoint, but the `[PolicyTrace USE]` log was only on the legacy `/for-ssh-user/:sshUser` route. So fresh round-trips after #42 produce no server-side USE line to compare against SIGN/ATTACH — making it impossible to confirm bytes match end-to-end with logs alone.

Add the same trace to the new endpoint.

## Test plan
- [ ] Deploy keylessh web app
- [ ] Connect SSH (gateway-qualified role) — confirm all three traces now appear and match:
  ```
  [PolicyTrace SIGN]   role=ssh:Tide-GW:My Server:demo dtv_sha=…
  [PolicyTrace USE]    role=ssh:Tide-GW:My Server:demo dtv_sha=…  ← new
  [PolicyTrace ATTACH] role=ssh:Tide-GW:My Server:demo dtv_sha=…
  ```