### PR TITLE
fix(sshPolicy): parse gateway-qualified roles in the Forseti contract

### DIFF
--- a/client/src/lib/sshPolicy.ts
+++ b/client/src/lib/sshPolicy.ts
@@ -46,11 +46,14 @@ public class Contract : IAccessPolicy
         if (string.IsNullOrWhiteSpace(Role))
             return PolicyDecision.Deny("Role is missing.");
 
-        var parts = Role.Split(':', 2, StringSplitOptions.TrimEntries);
-        if (parts.Length != 2 || parts[1].Length == 0)
-            return PolicyDecision.Deny("Role must be in the form 'prefix:role'.");
+        // Role IDs are gateway-qualified: ssh:<gatewayId>:<serverId>:<sshUser>
+        // (or legacy short-form ssh:<sshUser>). The SSH username we compare against
+        // the challenge is always the LAST colon-separated segment.
+        var lastColon = Role.LastIndexOf(':');
+        if (lastColon < 0 || lastColon == Role.Length - 1)
+            return PolicyDecision.Deny("Role must end with ':<sshUser>'.");
 
-        var userRole = parts[1];
+        var userRole = Role.Substring(lastColon + 1).Trim();
 
         if (ctx == null || ctx.Data == null || ctx.Data.Length == 0)
             return PolicyDecision.Deny("No data provided for SSH challenge validation");

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1513,11 +1513,14 @@ public class Contract : IAccessPolicy
         if (string.IsNullOrWhiteSpace(Role))
             return PolicyDecision.Deny("Role is missing.");
 
-        var parts = Role.Split(':', 2, StringSplitOptions.TrimEntries);
-        if (parts.Length != 2 || parts[1].Length == 0)
-            return PolicyDecision.Deny("Role must be in the form 'prefix:role'.");
+        // Role IDs are gateway-qualified: ssh:<gatewayId>:<serverId>:<sshUser>
+        // (or legacy short-form ssh:<sshUser>). The SSH username we compare against
+        // the challenge is always the LAST colon-separated segment.
+        var lastColon = Role.LastIndexOf(':');
+        if (lastColon < 0 || lastColon == Role.Length - 1)
+            return PolicyDecision.Deny("Role must end with ':<sshUser>'.");
 
-        var userRole = parts[1];
+        var userRole = Role.Substring(lastColon + 1).Trim();
 
         if (ctx == null || ctx.Data == null || ctx.Data.Length == 0)
             return PolicyDecision.Deny("No data provided for SSH challenge validation");


### PR DESCRIPTION
## Summary
The Forseti contract source shipped in \`client/src/lib/sshPolicy.ts\` (\`SSH_FORSETI_CONTRACT\`) used \`Role.Split(':', 2, …)\` to extract the SSH username from the policy's \`Role\` parameter. With \`max=2\`, only the first colon is consumed:

| Role param | parts[1] (wrongly used as userRole) |
|---|---|
| \`ssh:demo\` | \`demo\` ✓ (worked by accident on legacy short-form) |
| \`ssh:Tide-GW:My Server:demo\` | \`Tide-GW:My Server:demo\` ✗ |

So \`ValidateData\` would compare the SSH challenge's \`Username\` against \`"Tide-GW:My Server:demo"\` and always deny with \`"Not allowed to log in as <whoever>"\`.

This is the actual reason Sign #2 was failing post-fix — not a signature issue (PRs #40–#44 fixed those) but a contract-level mismatch surfaced only once the byte path was correct.

## Change
Extract everything after the **last** \`:\` in \`Role\`:
\`\`\`csharp
var lastColon = Role.LastIndexOf(':');
if (lastColon < 0 || lastColon == Role.Length - 1)
    return PolicyDecision.Deny("Role must end with ':<sshUser>'.");
var userRole = Role.Substring(lastColon + 1).Trim();
\`\`\`

Works for both formats:
- Legacy: \`ssh:demo\` → \`userRole = "demo"\`
- Current: \`ssh:Tide-GW:My Server:demo\` → \`userRole = "demo"\`

## Deploy notes
The contract source is uploaded to the ORK at **policy commit time**. After this lands:
1. Deploy keylessh
2. Re-commit any existing policy you want to use — the new commit uploads the patched contract source
3. (Old committed policies still reference the old contract source; either recommit or live with denials)

## Test plan
- [x] Existing \`tests/client/sshPolicy.test.ts\` — 35/35 pass after change
- [ ] Deploy, re-commit \`ssh:Tide-GW:My Server:demo\`
- [ ] Connect SSH as \`demo\` — should now reach the SSH terminal