### PR TITLE
fix(policy): restore signed policyData compose on commit

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2473,10 +2473,13 @@ export async function registerRoutes(
 
           if (signature) {
             const signatureBytes = base64ToBytes(signature);
-            policy.signature = signatureBytes;
+            // Stored policyData layout: TideMemory([ DataToVerify, signature ])
+            // — section 0 byte-identical to what the ORK signed, section 1 = the new signature.
+            const composed = TideMemory.CreateFromArray([dataToVerify, signatureBytes]);
+            policyDataBase64 = bytesToBase64(composed);
             // Preserve the detached sig for the iga-core policySig mirror field.
             policySigBase64 = bytesToBase64(signatureBytes);
-            log(`Attached VVK signature to policy (${signatureBytes.length} bytes)`);
+            log(`Composed signed policy: dtv=${dataToVerify.length}B sig=${signatureBytes.length}B total=${composed.length}B`);
           } else {
             log(`Warning: No signature provided for policy commit — storing policy without signature`);
             policyDataBase64 = bytesToBase64(policyBytesNoSig);


### PR DESCRIPTION
## Problem
SSH (and likely RDP) logins fail at ORK PreSign with `Policy signature could not be verified`.

## Root cause
The #46 merge resolved a conflict in the `POST /api/admin/ssh-policies/pending/:id/commit` handler by resurrecting pre-0f77356 code:

```ts
policy.signature = signatureBytes; // ReferenceError: policy is not defined
```

Every commit-with-signature threw, the surrounding catch swallowed it ("Warning: Failed to extract policy bytes"), so:
- the VVK-signed policy bytes were never upserted into `ssh_policies`
- `syncData` returned empty `policyData`/`policySig` to the client (iga-core sync got nothing)
- the pending policy was still marked committed, so the UI looked fine

At login time the client attaches the stale/unsigned stored policy and the ORK rejects it (`PolicyAuthorizationFlow.AuthorizeAsync`).

## Fix
Restore the compose logic from 0f77356 — store `TideMemory([DataToVerify, signature])` with section 0 byte-identical to what the ORK signed — while keeping the newer `policySig` mirror field required by the iga-core `role-policies` surface.

## Post-deploy action required
Policies committed while the bug was live hold bad bytes: re-run approve → commit for the affected roles so correctly signed `policyData` is stored and `policySig` syncs to iga-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)