### PR TITLE
Per-tenant gateway lists, remote config push, and VPN auth fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,16 @@ jobs:
         working-directory: bridges/punchd-bridge-rs/wix
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64
-          cl /LD /O2 ca\PunchdCA.c ca\PunchdCA.def /Fe:ca\PunchdCA.dll /link msi.lib advapi32.lib shell32.lib user32.lib ole32.lib
+          rem Locate Visual Studio via vswhere rather than a hardcoded path — the
+          rem runner image's VS edition and version change without notice, and a
+          rem stale path fails later as an unhelpful "'cl' is not recognized".
+          set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+          if not exist "%VSWHERE%" (echo ERROR: vswhere.exe not found & exit /b 1)
+          for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSPATH=%%i"
+          if not defined VSPATH (echo ERROR: no Visual Studio install with the C++ toolset & exit /b 1)
+          echo Using Visual Studio at %VSPATH%
+          call "%VSPATH%\Common7\Tools\VsDevCmd.bat" -arch=amd64 || exit /b 1
+          cl /LD /O2 ca\PunchdCA.c ca\PunchdCA.def /Fe:ca\PunchdCA.dll /link msi.lib advapi32.lib shell32.lib user32.lib ole32.lib || exit /b 1
 
       - name: Install WiX
         run: |

--- a/bridges/punchd-bridge-rs/Cargo.toml
+++ b/bridges/punchd-bridge-rs/Cargo.toml
@@ -53,6 +53,7 @@ arc-swap = "1"
 ipnet = "2"
 wry = { version = "0.55", optional = true }
 tao = { version = "0.35", optional = true }
+openssl = { version = "0.10.81", features = ["vendored"] }
 
 [features]
 default = []

--- a/bridges/punchd-bridge-rs/src/bin/punchd_vpn.rs
+++ b/bridges/punchd-bridge-rs/src/bin/punchd_vpn.rs
@@ -861,12 +861,14 @@ async fn main() {
 
     vpn_tray::set_refresh_callback(|| {
         tracing::info!("[Tray] Refresh Token requested");
-        // Clear cached token so next reconnect re-authenticates via WebView
-        if let Some(store) = webview_auth::get_latest_token() {
-            let _ = store; // token exists, will be refreshed on reconnect
+        // Drop the cached token and bring the login window back up. The window is
+        // hidden after the first login, so without this there is no way to reach a
+        // sign-in prompt once the session goes stale.
+        if webview_auth::webview_running() {
+            webview_auth::request_reauth();
+        } else {
+            tracing::warn!("[Tray] No login window available — reconnect to sign in");
         }
-        // Trigger WebView to show login window for fresh token
-        // (WebView is still running in background — it refreshes automatically)
     });
 
     vpn_tray::set_reconnect_callback(|| {
@@ -1427,10 +1429,19 @@ async fn oidc_login(_tc: &TcConfig) -> Result<String, String> {
     let app_url = std::env::var("SERVER_URL")
         .unwrap_or_else(|_| "https://demo.keylessh.com".to_string());
 
-    // If WebView is running in background, it may have a refreshed token already
+    // Reuse the WebView's token only while it is still good — get_latest_token
+    // returns None for an expired one so we fall through to a real login.
     if let Some(token) = webview_auth::get_latest_token() {
         tracing::info!("Using refreshed token from WebView");
         return Ok(token);
+    }
+
+    // A WebView already running means this is a re-auth: surface its window
+    // instead of spawning a second event loop that would never get a token.
+    if webview_auth::webview_running() {
+        tracing::info!("Token expired — reopening login window");
+        webview_auth::request_reauth();
+        return webview_auth::wait_for_token(std::time::Duration::from_secs(300)).await;
     }
 
     // Open embedded WebView for OIDC login (full DPoP via Heimdall)

--- a/bridges/punchd-bridge-rs/src/config.rs
+++ b/bridges/punchd-bridge-rs/src/config.rs
@@ -7,51 +7,51 @@ use std::path::PathBuf;
 
 use base64::Engine;
 use rand::Rng;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 // ── Config file schema (gateway.toml) ───────────────────────────
 
-#[derive(Deserialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 struct GatewayToml {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     gateway_id: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     stun_server_url: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     api_secret: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     backends: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     listen_port: Option<u16>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     health_port: Option<u16>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     https: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     tls_hostname: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     display_name: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     ice_servers: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     turn_server: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     turn_secret: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     tidecloak_config_path: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     tidecloak_config_b64: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     auth_server_public_url: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     tc_internal_url: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     strip_auth_header: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     server_url: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     quic_port: Option<u16>,
 }
 
@@ -133,6 +133,18 @@ pub struct TidecloakConfig {
     pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
+impl TidecloakConfig {
+    /// OIDC issuer this gateway trusts — the tenancy identity advertised to the
+    /// signal server so consoles only list gateways sharing their TideCloak realm.
+    pub fn issuer(&self) -> String {
+        format!(
+            "{}/realms/{}",
+            self.auth_server_url.trim_end_matches('/'),
+            self.realm
+        )
+    }
+}
+
 // ── Config file path ────────────────────────────────────────────
 
 /// Config directory: ~/.keylessh/ (or %APPDATA%\KeyleSSH\ on Windows)
@@ -167,6 +179,14 @@ static ON_CONFIG_CHANGE: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std:
 /// Register a callback that fires when config files change.
 pub fn on_config_change(cb: impl Fn() + Send + Sync + 'static) {
     let _ = ON_CONFIG_CHANGE.set(Box::new(cb));
+}
+
+/// Run the reload callback now. Used after a remote config push, which writes
+/// the file itself and so does not need to wait for the watcher.
+pub fn notify_config_changed() {
+    if let Some(cb) = ON_CONFIG_CHANGE.get() {
+        cb();
+    }
 }
 
 /// Watch gateway.toml and tidecloak config for changes using OS-native file notifications
@@ -272,6 +292,199 @@ pub fn config_file_path() -> PathBuf {
         }
     }
     dir.join("gateway.toml")
+}
+
+// ── Remote config push ──────────────────────────────────────────
+
+/// Fields that may never be set from a remote push.
+///
+/// `tidecloak_config_*`, `auth_server_public_url` and `tc_internal_url` define
+/// which TideCloak this gateway trusts — accepting them over the wire would let
+/// anyone holding the signal server's shared API secret repoint a gateway at
+/// their own IdP and mint access to every backend behind it. `gateway_id`,
+/// `stun_server_url` and `api_secret` are this gateway's own identity and
+/// bootstrap; letting a push rewrite them would allow hijacking it onto a
+/// different signal server. All of these stay a deliberate local action.
+pub const PROTECTED_FIELDS: &[&str] = &[
+    "gateway_id",
+    "stun_server_url",
+    "api_secret",
+    "tidecloak_config_b64",
+    "tidecloak_config_path",
+    "auth_server_public_url",
+    "tc_internal_url",
+];
+
+#[derive(Debug, Default, Serialize)]
+pub struct RejectedField {
+    pub field: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct RemoteConfigOutcome {
+    /// Fields whose value actually changed.
+    pub applied: Vec<String>,
+    /// Fields refused, with why.
+    pub rejected: Vec<RejectedField>,
+    /// False when every field was already at the requested value.
+    pub changed: bool,
+    /// Set when the config could not be read or written at all.
+    pub error: Option<String>,
+}
+
+impl RemoteConfigOutcome {
+    fn failed(error: impl Into<String>) -> Self {
+        Self { error: Some(error.into()), ..Default::default() }
+    }
+
+    fn reject(&mut self, field: &str, reason: impl Into<String>) {
+        self.rejected.push(RejectedField { field: field.to_string(), reason: reason.into() });
+    }
+}
+
+fn try_load_toml() -> Result<GatewayToml, String> {
+    let path = config_file_path();
+    if !path.exists() {
+        return Ok(GatewayToml::default());
+    }
+    let content = fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    toml::from_str(&content).map_err(|e| format!("parse {}: {e}", path.display()))
+}
+
+/// Merge a remotely-pushed config patch into gateway.toml.
+///
+/// Only the fields outside [`PROTECTED_FIELDS`] are honoured; everything else is
+/// reported back as rejected so the console can show what was refused.
+pub fn apply_remote_config(patch: &serde_json::Map<String, serde_json::Value>) -> RemoteConfigOutcome {
+    let original = match try_load_toml() {
+        Ok(c) => c,
+        Err(e) => return RemoteConfigOutcome::failed(e),
+    };
+
+    let (updated, mut outcome) = merge_remote_config(&original, patch);
+    if !outcome.changed {
+        return outcome;
+    }
+
+    if let Err(e) = write_toml(&updated) {
+        outcome.error = Some(e);
+        outcome.applied.clear();
+        outcome.changed = false;
+        return outcome;
+    }
+
+    tracing::info!("[Config] Applied remote config: {}", outcome.applied.join(", "));
+
+    // Trigger the reload directly rather than waiting on the file watcher: the
+    // watcher follows an inode, and the atomic rename in `write_toml` replaces
+    // it, so it cannot be relied on for a second push.
+    notify_config_changed();
+    outcome
+}
+
+/// Pure part of [`apply_remote_config`]: overlay the patch onto a config and
+/// report what was applied or refused, touching no files.
+fn merge_remote_config(
+    original: &GatewayToml,
+    patch: &serde_json::Map<String, serde_json::Value>,
+) -> (GatewayToml, RemoteConfigOutcome) {
+    let mut outcome = RemoteConfigOutcome::default();
+    let mut updated = original.clone();
+
+    // Coercion helpers: record a rejection when the pushed JSON type is wrong.
+    macro_rules! set_str {
+        ($field:ident, $key:expr, $value:expr) => {
+            match $value {
+                serde_json::Value::Null => updated.$field = None,
+                serde_json::Value::String(s) => updated.$field = Some(s.clone()),
+                _ => outcome.reject($key, "expected a string"),
+            }
+        };
+    }
+    macro_rules! set_port {
+        ($field:ident, $key:expr, $value:expr) => {
+            match $value.as_u64() {
+                Some(n) if n > 0 && n <= u16::MAX as u64 => updated.$field = Some(n as u16),
+                _ if $value.is_null() => updated.$field = None,
+                _ => outcome.reject($key, "expected a port between 1 and 65535"),
+            }
+        };
+    }
+    macro_rules! set_bool {
+        ($field:ident, $key:expr, $value:expr) => {
+            match $value.as_bool() {
+                Some(b) => updated.$field = Some(b),
+                None if $value.is_null() => updated.$field = None,
+                None => outcome.reject($key, "expected true or false"),
+            }
+        };
+    }
+
+    for (key, value) in patch {
+        if PROTECTED_FIELDS.contains(&key.as_str()) {
+            outcome.reject(key, "set locally on the gateway only");
+            continue;
+        }
+        match key.as_str() {
+            "backends" => set_str!(backends, key, value),
+            "display_name" => set_str!(display_name, key, value),
+            "description" => set_str!(description, key, value),
+            "ice_servers" => set_str!(ice_servers, key, value),
+            "turn_server" => set_str!(turn_server, key, value),
+            "turn_secret" => set_str!(turn_secret, key, value),
+            "tls_hostname" => set_str!(tls_hostname, key, value),
+            "server_url" => set_str!(server_url, key, value),
+            "listen_port" => set_port!(listen_port, key, value),
+            "health_port" => set_port!(health_port, key, value),
+            "quic_port" => set_port!(quic_port, key, value),
+            "https" => set_bool!(https, key, value),
+            "strip_auth_header" => set_bool!(strip_auth_header, key, value),
+            _ => outcome.reject(key, "unknown field"),
+        }
+    }
+
+    // Report only fields that genuinely differ, so a repeated push does not
+    // churn the gateway into a pointless reload.
+    outcome.applied = changed_fields(original, &updated);
+    outcome.changed = !outcome.applied.is_empty();
+    (updated, outcome)
+}
+
+/// Names of the fields that differ between two configs.
+fn changed_fields(a: &GatewayToml, b: &GatewayToml) -> Vec<String> {
+    let (av, bv) = (
+        serde_json::to_value(a).unwrap_or_default(),
+        serde_json::to_value(b).unwrap_or_default(),
+    );
+    let (ao, bo) = match (av.as_object(), bv.as_object()) {
+        (Some(ao), Some(bo)) => (ao, bo),
+        _ => return Vec::new(),
+    };
+    let mut keys: Vec<&String> = ao.keys().chain(bo.keys()).collect();
+    keys.sort();
+    keys.dedup();
+    keys.into_iter()
+        .filter(|key| ao.get(*key) != bo.get(*key))
+        .cloned()
+        .collect()
+}
+
+/// Write gateway.toml atomically so a crash mid-write cannot truncate the config
+/// the gateway needs to restart.
+fn write_toml(config: &GatewayToml) -> Result<(), String> {
+    let path = config_file_path();
+    let body = toml::to_string_pretty(config).map_err(|e| format!("serialize config: {e}"))?;
+    let contents = format!(
+        "# Punchd Gateway Configuration\n\
+         # Managed from the KeyleSSH console — edits here are overwritten on the next push.\n\
+         # TideCloak settings and signal server identity are local-only and never pushed.\n\n{body}"
+    );
+
+    let tmp = path.with_extension("toml.tmp");
+    fs::write(&tmp, contents).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+    fs::rename(&tmp, &path).map_err(|e| format!("replace {}: {e}", path.display()))?;
+    Ok(())
 }
 
 fn load_toml() -> GatewayToml {
@@ -564,5 +777,158 @@ fn detect_lan_ip() -> String {
 mod hex {
     pub fn encode(bytes: &[u8]) -> String {
         bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+}
+
+#[cfg(test)]
+mod remote_config_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn patch(value: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+        value.as_object().expect("patch must be an object").clone()
+    }
+
+    fn base() -> GatewayToml {
+        GatewayToml {
+            gateway_id: Some("gw-1".into()),
+            stun_server_url: Some("wss://signal.example.com".into()),
+            api_secret: Some("shared-secret".into()),
+            backends: Some("App=http://10.0.0.5:8080".into()),
+            tidecloak_config_b64: Some("ZXhpc3Rpbmc=".into()),
+            auth_server_public_url: Some("https://tc.example.com".into()),
+            listen_port: Some(7891),
+            https: Some(true),
+            ..Default::default()
+        }
+    }
+
+    fn rejected_reason(outcome: &RemoteConfigOutcome, field: &str) -> Option<String> {
+        outcome.rejected.iter().find(|r| r.field == field).map(|r| r.reason.clone())
+    }
+
+    #[test]
+    fn applies_backends_and_ports() {
+        let p = patch(json!({
+            "backends": "App=http://10.0.0.5:8080, Db=rdp://10.0.0.9:3389;eddsa",
+            "listen_port": 9000,
+        }));
+        let (updated, outcome) = merge_remote_config(&base(), &p);
+
+        assert!(outcome.changed);
+        assert_eq!(outcome.rejected.len(), 0);
+        assert_eq!(updated.backends.as_deref(), Some("App=http://10.0.0.5:8080, Db=rdp://10.0.0.9:3389;eddsa"));
+        assert_eq!(updated.listen_port, Some(9000));
+        let mut applied = outcome.applied.clone();
+        applied.sort();
+        assert_eq!(applied, vec!["backends", "listen_port"]);
+    }
+
+    #[test]
+    fn refuses_to_repoint_the_trust_anchor() {
+        let p = patch(json!({
+            "tidecloak_config_b64": "YXR0YWNrZXI=",
+            "auth_server_public_url": "https://attacker.example.com",
+            "tc_internal_url": "https://attacker.example.com",
+        }));
+        let (updated, outcome) = merge_remote_config(&base(), &p);
+
+        assert!(!outcome.changed, "a push must never change the trust anchor");
+        assert!(outcome.applied.is_empty());
+        assert_eq!(updated.tidecloak_config_b64.as_deref(), Some("ZXhpc3Rpbmc="));
+        assert_eq!(updated.auth_server_public_url.as_deref(), Some("https://tc.example.com"));
+        for field in ["tidecloak_config_b64", "auth_server_public_url", "tc_internal_url"] {
+            assert_eq!(rejected_reason(&outcome, field).as_deref(), Some("set locally on the gateway only"));
+        }
+    }
+
+    #[test]
+    fn refuses_to_hijack_gateway_identity() {
+        let p = patch(json!({
+            "gateway_id": "someone-elses-gateway",
+            "stun_server_url": "wss://attacker.example.com",
+            "api_secret": "new-secret",
+        }));
+        let (updated, outcome) = merge_remote_config(&base(), &p);
+
+        assert!(!outcome.changed);
+        assert_eq!(updated.gateway_id.as_deref(), Some("gw-1"));
+        assert_eq!(updated.stun_server_url.as_deref(), Some("wss://signal.example.com"));
+        assert_eq!(updated.api_secret.as_deref(), Some("shared-secret"));
+        assert_eq!(outcome.rejected.len(), 3);
+    }
+
+    #[test]
+    fn a_rejected_field_does_not_block_the_allowed_ones() {
+        let p = patch(json!({ "backends": "App=http://10.0.0.6:8080", "api_secret": "nope" }));
+        let (updated, outcome) = merge_remote_config(&base(), &p);
+
+        assert_eq!(outcome.applied, vec!["backends"]);
+        assert_eq!(updated.backends.as_deref(), Some("App=http://10.0.0.6:8080"));
+        assert_eq!(updated.api_secret.as_deref(), Some("shared-secret"));
+    }
+
+    #[test]
+    fn repeated_push_of_the_same_values_is_a_no_op() {
+        let p = patch(json!({ "backends": "App=http://10.0.0.5:8080", "listen_port": 7891 }));
+        let (_, outcome) = merge_remote_config(&base(), &p);
+
+        assert!(!outcome.changed, "unchanged values must not trigger a reload");
+        assert!(outcome.applied.is_empty());
+    }
+
+    #[test]
+    fn wrong_types_are_rejected_not_coerced() {
+        let p = patch(json!({ "listen_port": "9000", "https": "yes", "backends": 42 }));
+        let (updated, outcome) = merge_remote_config(&base(), &p);
+
+        assert!(!outcome.changed);
+        assert_eq!(updated.listen_port, Some(7891));
+        assert_eq!(updated.https, Some(true));
+        assert_eq!(rejected_reason(&outcome, "listen_port").as_deref(), Some("expected a port between 1 and 65535"));
+        assert_eq!(rejected_reason(&outcome, "https").as_deref(), Some("expected true or false"));
+        assert_eq!(rejected_reason(&outcome, "backends").as_deref(), Some("expected a string"));
+    }
+
+    #[test]
+    fn out_of_range_ports_are_rejected() {
+        let p = patch(json!({ "listen_port": 0, "health_port": 70000 }));
+        let (updated, outcome) = merge_remote_config(&base(), &p);
+
+        assert!(!outcome.changed);
+        assert_eq!(updated.listen_port, Some(7891));
+        assert_eq!(outcome.rejected.len(), 2);
+    }
+
+    #[test]
+    fn unknown_fields_are_reported_rather_than_silently_dropped() {
+        let p = patch(json!({ "totally_made_up": "x" }));
+        let (_, outcome) = merge_remote_config(&base(), &p);
+
+        assert_eq!(rejected_reason(&outcome, "totally_made_up").as_deref(), Some("unknown field"));
+    }
+
+    #[test]
+    fn null_clears_an_optional_field() {
+        let p = patch(json!({ "turn_server": null }));
+        let mut original = base();
+        original.turn_server = Some("turn:1.2.3.4:3478".into());
+        let (updated, outcome) = merge_remote_config(&original, &p);
+
+        assert!(outcome.changed);
+        assert_eq!(updated.turn_server, None);
+    }
+
+    #[test]
+    fn serialized_config_omits_unset_fields() {
+        let (updated, _) = merge_remote_config(&base(), &patch(json!({ "listen_port": 9000 })));
+        let rendered = toml::to_string_pretty(&updated).expect("serializes");
+
+        assert!(rendered.contains("listen_port = 9000"));
+        assert!(!rendered.contains("description"), "unset fields must not be written as empty keys");
+        // Round-trips: the gateway must be able to read back what it wrote.
+        let reparsed: GatewayToml = toml::from_str(&rendered).expect("parses");
+        assert_eq!(reparsed.listen_port, Some(9000));
+        assert_eq!(reparsed.gateway_id.as_deref(), Some("gw-1"));
     }
 }

--- a/bridges/punchd-bridge-rs/src/main.rs
+++ b/bridges/punchd-bridge-rs/src/main.rs
@@ -166,6 +166,10 @@ async fn run_gateway() {
             if hosts_tc_locally {
                 meta["realm"] = serde_json::json!(tc_config.realm);
             }
+            // Always advertised, unlike `realm` — descriptive only, so it never
+            // affects HTTP relay routing. Lets consoles filter to their own tenant.
+            meta["issuer"] = serde_json::json!(tc_config.issuer());
+            meta["clientId"] = serde_json::json!(tc_config.resource);
             if let Ok(public_url) = std::env::var("PUBLIC_URL") {
                 meta["publicUrl"] = serde_json::json!(public_url);
             }
@@ -217,6 +221,8 @@ async fn run_gateway() {
             if hosts_tc_locally {
                 meta["realm"] = serde_json::json!(new_tc_config.realm);
             }
+            meta["issuer"] = serde_json::json!(new_tc_config.issuer());
+            meta["clientId"] = serde_json::json!(new_tc_config.resource);
             stun_reg.update_metadata(meta);
         });
     }

--- a/bridges/punchd-bridge-rs/src/stun/stun_client.rs
+++ b/bridges/punchd-bridge-rs/src/stun/stun_client.rs
@@ -445,6 +445,31 @@ async fn connect_and_run(
                                     options.gateway_id
                                 );
                             }
+                            "config_update" => {
+                                // Config pushed from the console. Trust-anchor and
+                                // identity fields are refused by apply_remote_config;
+                                // everything applied lands in gateway.toml and triggers
+                                // the normal reload path.
+                                let request_id = parsed["requestId"].as_str().unwrap_or("").to_string();
+                                let empty = serde_json::Map::new();
+                                let patch = parsed["config"].as_object().unwrap_or(&empty);
+                                tracing::info!("[STUN-Reg] Config push received ({} field(s))", patch.len());
+
+                                let outcome = crate::config::apply_remote_config(patch);
+                                if let Some(ref err) = outcome.error {
+                                    tracing::warn!("[STUN-Reg] Config push failed: {err}");
+                                }
+
+                                let _ = signaling_tx.send(serde_json::json!({
+                                    "type": "config_ack",
+                                    "requestId": request_id,
+                                    "gatewayId": options.gateway_id,
+                                    "applied": outcome.applied,
+                                    "rejected": outcome.rejected,
+                                    "changed": outcome.changed,
+                                    "error": outcome.error,
+                                }));
+                            }
                             "paired" => {
                                 if let Some(client) = parsed.get("client") {
                                     let client_id = client["id"].as_str().unwrap_or("unknown").to_string();

--- a/bridges/punchd-bridge-rs/src/vpn/webview_auth.rs
+++ b/bridges/punchd-bridge-rs/src/vpn/webview_auth.rs
@@ -19,8 +19,24 @@ fn token_store() -> &'static Mutex<Option<String>> {
     LATEST_TOKEN.get_or_init(|| Mutex::new(None))
 }
 
-/// Get the latest token from the WebView (if one has been received).
+/// Get the latest *usable* token from the WebView.
+///
+/// The WebView's storage survives restarts, so the token found on startup is
+/// frequently a leftover from the previous session. Returning an expired one
+/// makes the caller skip login and then fail against the gateway, which looks
+/// to the user like the app quitting without ever asking them to sign in.
 pub fn get_latest_token() -> Option<String> {
+    let token = token_store().lock().ok()?.clone()?;
+    if token_is_usable(&token) {
+        Some(token)
+    } else {
+        tracing::info!("[WebView] Cached token is expired — login required");
+        None
+    }
+}
+
+/// Get whatever token is cached, expired or not. Only for diagnostics.
+pub fn peek_latest_token() -> Option<String> {
     token_store().lock().ok()?.clone()
 }
 
@@ -28,6 +44,51 @@ fn set_latest_token(token: &str) {
     if let Ok(mut store) = token_store().lock() {
         *store = Some(token.to_string());
     }
+}
+
+fn clear_latest_token() {
+    if let Ok(mut store) = token_store().lock() {
+        *store = None;
+    }
+}
+
+/// Seconds of headroom required on a token. A token about to expire is treated
+/// as already expired so a connection isn't started with one that dies mid-handshake.
+const TOKEN_MIN_REMAINING_SECS: u64 = 30;
+
+/// Whether a JWT is well-formed and has enough life left to start a connection.
+///
+/// This is not signature verification — the gateway does that. It only prevents
+/// the client from confidently presenting a token it can already see is stale.
+pub fn token_is_usable(token: &str) -> bool {
+    match token_expiry(token) {
+        // No `exp` claim: nothing to judge it by, so let the gateway decide.
+        Some(None) => true,
+        Some(Some(exp)) => {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            exp > now.saturating_add(TOKEN_MIN_REMAINING_SECS)
+        }
+        // Unparseable: not a JWT this client can use.
+        None => false,
+    }
+}
+
+/// Parse a JWT's `exp` claim. `None` if the token is malformed;
+/// `Some(None)` if it parses but carries no `exp`.
+fn token_expiry(token: &str) -> Option<Option<u64>> {
+    use base64::Engine;
+
+    let payload_b64 = token.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(payload_b64))
+        .or_else(|_| base64::engine::general_purpose::STANDARD.decode(payload_b64))
+        .ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    Some(claims.get("exp").and_then(|e| e.as_u64()))
 }
 
 /// Global channel for DPoP proof responses (WebView JS → Rust).
@@ -52,6 +113,54 @@ fn send_to_webview(msg: &str) {
             let _ = proxy.send_event(msg.to_string());
         }
     }
+}
+
+/// Bring the login window back up and clear the stale session behind it.
+///
+/// The window is hidden after the first successful login and the app keeps
+/// running, so without this there is no path back to a visible login prompt —
+/// which is why "Refresh Token" appeared to do nothing once a token went stale.
+#[cfg(feature = "webview")]
+pub fn request_reauth() {
+    clear_latest_token();
+    send_to_webview("reauth");
+}
+
+#[cfg(not(feature = "webview"))]
+pub fn request_reauth() {
+    clear_latest_token();
+}
+
+/// Wait for the WebView to produce a usable token, polling the store.
+///
+/// Used when a login window already exists and has been asked to re-authenticate:
+/// the initial-token channel belongs to the original login, so the token from a
+/// second sign-in arrives through the store instead.
+pub async fn wait_for_token(timeout: std::time::Duration) -> Result<String, String> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(token) = get_latest_token() {
+            return Ok(token);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err("Timed out waiting for sign-in".into());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+}
+
+/// Whether a login window is currently available to be shown.
+#[cfg(feature = "webview")]
+pub fn webview_running() -> bool {
+    EVENT_PROXY
+        .get()
+        .and_then(|m| m.lock().ok().map(|g| g.is_some()))
+        .unwrap_or(false)
+}
+
+#[cfg(not(feature = "webview"))]
+pub fn webview_running() -> bool {
+    false
 }
 
 /// Request a DPoP proof from the WebView.
@@ -103,7 +212,7 @@ pub async fn request_dpop_proof(_method: &str, _url: &str) -> Result<String, Str
 
 #[cfg(feature = "webview")]
 mod imp {
-    use super::{set_latest_token, set_dpop_response, EVENT_PROXY};
+    use super::{set_latest_token, clear_latest_token, set_dpop_response, token_is_usable, EVENT_PROXY};
 
     /// Embedded WebView2Loader.dll — extracted next to the exe at runtime.
     #[cfg(target_os = "windows")]
@@ -179,11 +288,47 @@ mod imp {
             (function() {
                 let lastToken = null;
                 let sentInitialToken = false;
+                let reportedAuthRequired = false;
+
+                // Storage survives restarts, so the token present on load is
+                // often left over from a previous session. Check it before
+                // reporting it — otherwise the app skips login and then fails.
+                function secondsRemaining(token) {
+                    try {
+                        const payload = JSON.parse(atob(
+                            token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")
+                        ));
+                        if (!payload.exp) return Infinity;  // nothing to judge by
+                        return payload.exp - Math.floor(Date.now() / 1000);
+                    } catch (e) {
+                        return -1;  // unparseable: treat as unusable
+                    }
+                }
+
+                function isUsable(token) {
+                    return !!token && secondsRemaining(token) > 30;
+                }
 
                 // ── Token polling ──
                 function checkToken() {
                     const token = localStorage.getItem("access_token");
-                    if (token && token !== lastToken) {
+
+                    if (!isUsable(token)) {
+                        // No usable token. Tell Rust once so it can show this
+                        // window; the user is sitting in front of a login page.
+                        if (!reportedAuthRequired) {
+                            reportedAuthRequired = true;
+                            lastToken = null;
+                            window.ipc.postMessage(JSON.stringify({
+                                type: "auth_required",
+                                reason: token ? "expired" : "missing",
+                            }));
+                        }
+                        return;
+                    }
+
+                    reportedAuthRequired = false;
+                    if (token !== lastToken) {
                         lastToken = token;
                         window.ipc.postMessage(JSON.stringify({
                             type: "token",
@@ -195,7 +340,7 @@ mod imp {
                 }
                 setInterval(checkToken, 1000);
                 window.addEventListener("storage", function(e) {
-                    if (e.key === "access_token" && e.newValue) checkToken();
+                    if (e.key === "access_token") checkToken();
                 });
                 checkToken();
 
@@ -329,6 +474,13 @@ mod imp {
                         Some("token") => {
                             if let Some(token) = parsed["token"].as_str() {
                                 let is_initial = parsed["initial"].as_bool().unwrap_or(false);
+                                // Belt and braces: the page already filters expired
+                                // tokens, but never hide the window on one.
+                                if !token_is_usable(token) {
+                                    tracing::warn!("[WebView] Ignoring expired token from page");
+                                    let _ = proxy_clone.send_event("show".to_string());
+                                    return;
+                                }
                                 set_latest_token(token);
                                 if is_initial {
                                     tracing::info!("[WebView] Initial token received");
@@ -338,6 +490,15 @@ mod imp {
                                     tracing::info!("[WebView] Token refreshed");
                                 }
                             }
+                        }
+                        Some("auth_required") => {
+                            // The page has no usable token: either it never had
+                            // one, or a refresh failed. Either way the user has to
+                            // sign in, so the window must be in front of them.
+                            let reason = parsed["reason"].as_str().unwrap_or("unknown");
+                            tracing::info!("[WebView] Login required ({reason}) — showing window");
+                            clear_latest_token();
+                            let _ = proxy_clone.send_event("show".to_string());
                         }
                         Some("dpop_proof") => {
                             if let Some(proof) = parsed["proof"].as_str() {
@@ -372,6 +533,20 @@ mod imp {
                 }
                 Event::UserEvent(ref msg) if msg == "hide" => {
                     window.set_visible(false);
+                }
+                Event::UserEvent(ref msg) if msg == "show" => {
+                    window.set_visible(true);
+                    window.set_focus();
+                }
+                Event::UserEvent(ref msg) if msg == "reauth" => {
+                    // Drop the stale session and land back on the login page,
+                    // rather than showing a window still holding a dead token.
+                    let _ = webview.evaluate_script(
+                        "try { localStorage.removeItem('access_token'); } catch (e) {}",
+                    );
+                    let _ = webview.load_url(&login_url);
+                    window.set_visible(true);
+                    window.set_focus();
                 }
                 Event::UserEvent(ref msg) if msg == "close" => {
                     *control_flow = ControlFlow::Exit;
@@ -469,3 +644,79 @@ mod imp {
 
 pub use imp::webview_available;
 pub use imp::webview_oidc_login;
+
+#[cfg(test)]
+mod token_tests {
+    use super::*;
+    use base64::Engine;
+
+    fn jwt(claims: serde_json::Value) -> String {
+        let b64 = |v: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(v);
+        format!(
+            "{}.{}.{}",
+            b64(br#"{"alg":"EdDSA","typ":"JWT"}"#),
+            b64(claims.to_string().as_bytes()),
+            b64(b"not-a-real-signature"),
+        )
+    }
+
+    fn now() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    #[test]
+    fn accepts_a_token_with_life_left() {
+        assert!(token_is_usable(&jwt(serde_json::json!({ "exp": now() + 3600 }))));
+    }
+
+    #[test]
+    fn rejects_an_expired_token() {
+        // The startup bug: a token left in WebView storage by the previous
+        // session must not be accepted as a reason to skip login.
+        assert!(!token_is_usable(&jwt(serde_json::json!({ "exp": now() - 1 }))));
+        assert!(!token_is_usable(&jwt(serde_json::json!({ "exp": now() - 86_400 }))));
+    }
+
+    #[test]
+    fn rejects_a_token_about_to_expire() {
+        // Would die mid-handshake; treat as already gone.
+        assert!(!token_is_usable(&jwt(serde_json::json!({ "exp": now() + 5 }))));
+    }
+
+    #[test]
+    fn accepts_a_token_past_the_leeway() {
+        assert!(token_is_usable(&jwt(serde_json::json!({ "exp": now() + 120 }))));
+    }
+
+    #[test]
+    fn accepts_a_token_with_no_expiry_claim() {
+        // Nothing to judge it by — let the gateway be the authority.
+        assert!(token_is_usable(&jwt(serde_json::json!({ "sub": "user" }))));
+    }
+
+    #[test]
+    fn rejects_malformed_tokens() {
+        assert!(!token_is_usable(""));
+        assert!(!token_is_usable("not-a-jwt"));
+        assert!(!token_is_usable("only.two"));
+        assert!(!token_is_usable("header.!!!not-base64!!!.sig"));
+        assert!(!token_is_usable("header.bm90LWpzb24.sig"));
+    }
+
+    #[test]
+    fn get_latest_token_hides_an_expired_one() {
+        set_latest_token(&jwt(serde_json::json!({ "exp": now() - 1 })));
+        assert!(peek_latest_token().is_some(), "still cached for diagnostics");
+        assert!(get_latest_token().is_none(), "but not offered to the caller");
+
+        let good = jwt(serde_json::json!({ "exp": now() + 3600 }));
+        set_latest_token(&good);
+        assert_eq!(get_latest_token().as_deref(), Some(good.as_str()));
+
+        clear_latest_token();
+        assert!(get_latest_token().is_none());
+    }
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -548,14 +548,27 @@ export const api = {
       list: () => apiRequest<GatewayConfigSummary[]>("/api/admin/gateway-configs"),
       get: (id: string) => apiRequest<GatewayConfigSummary>(`/api/admin/gateway-configs/${id}`),
       create: (data: any) => apiRequest<GatewayConfigSummary>("/api/admin/gateway-configs", { method: "POST", body: JSON.stringify(data) }),
-      update: (id: string, data: any) => apiRequest<GatewayConfigSummary>(`/api/admin/gateway-configs/${id}`, { method: "PUT", body: JSON.stringify(data) }),
+      // Saving also pushes to the running gateway; `push` reports how that went.
+      update: (id: string, data: any) => apiRequest<GatewayConfigSummary & { push?: GatewayPushResult }>(`/api/admin/gateway-configs/${id}`, { method: "PUT", body: JSON.stringify(data) }),
       delete: (id: string) => apiRequest<void>(`/api/admin/gateway-configs/${id}`, { method: "DELETE" }),
+      push: (id: string) => apiRequest<GatewayPushResult>(`/api/admin/gateway-configs/${id}/push`, { method: "POST" }),
       downloadUrl: (id: string) => `/api/admin/gateway-configs/${id}/download`,
       vpnConfigUrl: (id: string) => `/api/admin/gateway-configs/${id}/vpn-config`,
       tidecloakConfigUrl: (id: string) => `/api/admin/gateway-configs/${id}/tidecloak-config`,
     },
   },
 };
+
+// Result of pushing a gateway config to the running gateway via the signal server
+export interface GatewayPushResult {
+  delivered: boolean;
+  pending: boolean;
+  applied: string[];
+  rejected: { field: string; reason: string }[];
+  changed: boolean;
+  error?: string | null;
+  message?: string;
+}
 
 // Gateway config (managed from admin UI)
 export interface GatewayConfigSummary {
@@ -595,6 +608,10 @@ export interface GatewayEndpoint {
   signalServerName: string;
   signalServerUrl: string;
   directUrl?: string;
+  /// TideCloak issuer the gateway trusts. The server only returns gateways
+  /// matching this instance's issuer, so a shared signal server does not leak
+  /// another deployment's gateways into this list.
+  issuer?: string | null;
 }
 
 // Re-export types for convenience

--- a/client/src/lib/backends.ts
+++ b/client/src/lib/backends.ts
@@ -1,0 +1,92 @@
+/**
+ * The gateway's `backends` setting is a single string using the format
+ * `Name=url;flag;flag, Name=url`. These helpers convert it to and from rows so
+ * the console can edit backends as fields instead of hand-written text.
+ *
+ * Kept in sync with `parse_backends_str` in the gateway's config.rs.
+ */
+
+export type BackendProtocol = "rdp" | "ssh" | "http";
+
+export interface BackendRow {
+  name: string;
+  url: string;
+  /** Skip JWT verification for this backend. */
+  noAuth: boolean;
+  /** Strip auth headers before forwarding to the backend. */
+  stripAuth: boolean;
+  /** Passwordless RDP using EdDSA certificates. */
+  eddsa: boolean;
+}
+
+export const EMPTY_BACKEND: BackendRow = {
+  name: "",
+  url: "",
+  noAuth: false,
+  stripAuth: false,
+  eddsa: false,
+};
+
+/** Protocol the gateway infers from a backend URL. */
+export function backendProtocol(url: string): BackendProtocol {
+  const trimmed = url.trim().toLowerCase();
+  if (trimmed.startsWith("rdp://")) return "rdp";
+  if (trimmed.startsWith("ssh://")) return "ssh";
+  return "http";
+}
+
+/**
+ * Parse a backends string into rows. Malformed entries (no `=`, or an empty
+ * URL) are dropped, matching what the gateway would refuse to load.
+ */
+export function parseBackends(input: string | null | undefined): BackendRow[] {
+  if (!input) return [];
+
+  return input
+    .split(",")
+    .map((entry) => {
+      const eq = entry.indexOf("=");
+      if (eq === -1) return null;
+
+      const name = entry.slice(0, eq).trim();
+      let url = entry.slice(eq + 1).trim().replace(/;+$/, "");
+
+      const row: BackendRow = { ...EMPTY_BACKEND, name };
+
+      // Flags are suffixes and may repeat in any order.
+      for (;;) {
+        const lower = url.toLowerCase();
+        if (lower.endsWith(";noauth")) {
+          row.noAuth = true;
+          url = url.slice(0, -";noauth".length).trim();
+        } else if (lower.endsWith(";stripauth")) {
+          row.stripAuth = true;
+          url = url.slice(0, -";stripauth".length).trim();
+        } else if (lower.endsWith(";eddsa")) {
+          row.eddsa = true;
+          url = url.slice(0, -";eddsa".length).trim();
+        } else {
+          break;
+        }
+      }
+
+      if (!name || !url) return null;
+      return { ...row, url };
+    })
+    .filter((row): row is BackendRow => row !== null);
+}
+
+/** Render rows back to the gateway's backends string. Blank rows are skipped. */
+export function serializeBackends(rows: BackendRow[]): string {
+  return rows
+    .filter((row) => row.name.trim() && row.url.trim())
+    .map((row) => {
+      const flags = [
+        row.noAuth ? ";noauth" : "",
+        row.stripAuth ? ";stripauth" : "",
+        row.eddsa ? ";eddsa" : "",
+      ].join("");
+      return `${row.name.trim()}=${row.url.trim()}${flags}`;
+    })
+    .join(", ");
+}

--- a/client/src/pages/AdminGateways.tsx
+++ b/client/src/pages/AdminGateways.tsx
@@ -19,14 +19,21 @@ import {
 } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
 import { queryClient } from "@/lib/queryClient";
-import { api, type GatewayConfigSummary } from "@/lib/api";
+import { api, type GatewayConfigSummary, type GatewayPushResult } from "@/lib/api";
+import {
+  parseBackends,
+  serializeBackends,
+  backendProtocol,
+  EMPTY_BACKEND,
+  type BackendRow,
+} from "@/lib/backends";
 import { useAutoRefresh } from "@/hooks/useAutoRefresh";
 import { RefreshButton } from "@/components/RefreshButton";
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Router, Plus, Pencil, Trash2, Download, Wifi, Copy, Check, KeyRound, FileDown, Shield, Settings } from "lucide-react";
+import { Router, Plus, Pencil, Trash2, Download, Wifi, Copy, Check, KeyRound, FileDown, Shield, Settings, UploadCloud, Loader2 } from "lucide-react";
 import type { SignalServer } from "@shared/schema";
 import { useAuth, useAuthConfig } from "@/contexts/AuthContext";
 import { useMemo } from "react";
@@ -73,6 +80,120 @@ function SshPublicKeyBanner() {
       </div>
     </div>
   );
+}
+
+/**
+ * Edit backends as rows instead of the `Name=url;flags` string the gateway
+ * stores. The string stays the source of truth — rows are derived on each
+ * render — so anything hand-written elsewhere still round-trips.
+ */
+function BackendsEditor({ value, onChange }: { value: string; onChange: (backends: string) => void }) {
+  const rows = useMemo(() => parseBackends(value), [value]);
+  const [raw, setRaw] = useState(false);
+
+  const update = (index: number, patch: Partial<BackendRow>) => {
+    const next = rows.map((row, i) => (i === index ? { ...row, ...patch } : row));
+    onChange(serializeBackends(next));
+  };
+
+  const add = () => onChange(serializeBackends([...rows, { ...EMPTY_BACKEND, name: "", url: "http://" }]));
+  const remove = (index: number) => onChange(serializeBackends(rows.filter((_, i) => i !== index)));
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">Backends <span className="text-muted-foreground font-normal">(optional)</span></Label>
+        <button
+          type="button"
+          onClick={() => setRaw(!raw)}
+          className="text-[10px] text-muted-foreground hover:text-foreground underline underline-offset-2"
+        >
+          {raw ? "Edit as rows" : "Edit as text"}
+        </button>
+      </div>
+
+      {raw ? (
+        <Input
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="Name=rdp://host:3389;eddsa"
+          className="font-mono text-xs"
+        />
+      ) : (
+        <div className="space-y-2">
+          {rows.map((row, i) => (
+            <div key={i} className="rounded-md border border-border p-2 space-y-2">
+              <div className="flex gap-2">
+                <Input
+                  value={row.name}
+                  onChange={(e) => update(i, { name: e.target.value })}
+                  placeholder="Name"
+                  className="h-8 text-xs w-1/3"
+                />
+                <Input
+                  value={row.url}
+                  onChange={(e) => update(i, { url: e.target.value })}
+                  placeholder="rdp://10.0.0.9:3389"
+                  className="h-8 text-xs flex-1 font-mono"
+                />
+                <Badge variant="outline" className="h-8 px-2 text-[10px] uppercase shrink-0 flex items-center">
+                  {backendProtocol(row.url)}
+                </Badge>
+                <Button type="button" size="icon" variant="ghost" className="h-8 w-8 shrink-0" onClick={() => remove(i)}>
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 pl-1">
+                {([
+                  ["eddsa", "EdDSA", "Passwordless RDP using EdDSA certificates"],
+                  ["noAuth", "No auth", "Skip JWT verification for this backend"],
+                  ["stripAuth", "Strip auth", "Remove auth headers before forwarding"],
+                ] as const).map(([key, label, title]) => (
+                  <label key={key} className="flex items-center gap-1.5 text-[11px] text-muted-foreground" title={title}>
+                    <input
+                      type="checkbox"
+                      checked={row[key]}
+                      onChange={(e) => update(i, { [key]: e.target.checked })}
+                      className="h-3 w-3 accent-[hsl(var(--neon-cyan))]"
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+
+          <Button type="button" variant="outline" size="sm" className="w-full gap-1.5 h-8 text-xs" onClick={add}>
+            <Plus className="h-3.5 w-3.5" /> Add backend
+          </Button>
+        </div>
+      )}
+
+      <p className="text-[10px] text-muted-foreground">
+        Pre-configured endpoints. Leave empty to use custom IP connections only.
+      </p>
+    </div>
+  );
+}
+
+/** Turn a push result into something worth reading in a toast. */
+function describePush(push: GatewayPushResult): { title: string; description?: string; variant?: "destructive" } {
+  if (push.error) {
+    return { title: "Saved — gateway not updated", description: push.error, variant: "destructive" };
+  }
+  if (push.pending) {
+    return { title: "Saved — gateway offline", description: push.message || "Config will apply when the gateway reconnects." };
+  }
+  const refused = push.rejected.length
+    ? ` Refused: ${push.rejected.map((r) => `${r.field} (${r.reason})`).join(", ")}.`
+    : "";
+  if (!push.changed) {
+    return { title: "Gateway already up to date", description: refused.trim() || undefined };
+  }
+  return {
+    title: "Applied to gateway",
+    description: `Updated ${push.applied.join(", ")}.${refused}`,
+  };
 }
 
 const defaultForm: Partial<GatewayConfigSummary> = {
@@ -132,12 +253,20 @@ export default function AdminGateways() {
 
   const updateMutation = useMutation({
     mutationFn: ({ id, data }: { id: string; data: any }) => api.admin.gatewayConfigs.update(id, data),
-    onSuccess: () => {
+    onSuccess: (result: GatewayConfigSummary & { push?: GatewayPushResult }) => {
       queryClient.invalidateQueries({ queryKey: ["/api/admin/gateway-configs"] });
       setEditing(null);
-      toast({ title: "Gateway config updated" });
+      // Saving pushes to the running gateway — report what actually happened
+      // there, since that is the part the admin cannot otherwise see.
+      toast(result.push ? describePush(result.push) : { title: "Gateway config updated" });
     },
     onError: (e: Error) => toast({ title: "Failed to update", description: e.message, variant: "destructive" }),
+  });
+
+  const pushMutation = useMutation({
+    mutationFn: (id: string) => api.admin.gatewayConfigs.push(id),
+    onSuccess: (push) => toast(describePush(push)),
+    onError: (e: Error) => toast({ title: "Push failed", description: e.message, variant: "destructive" }),
   });
 
   const deleteMutation = useMutation({
@@ -235,16 +364,10 @@ export default function AdminGateways() {
         <p className="text-[10px] text-muted-foreground">STUN/TURN and API secret are inherited from the signal server config.</p>
       </div>
 
-      <div className="space-y-1">
-        <Label className="text-xs">Backends <span className="text-muted-foreground font-normal">(optional)</span></Label>
-        <Input value={form.backends || ""} onChange={(e) => setForm({ ...form, backends: e.target.value })} placeholder="Name=rdp://host:3389;eddsa" />
-        <p className="text-[10px] text-muted-foreground">Pre-configured endpoints. Leave empty to use custom IP connections only. Format: Name=url;flags, comma-separated.</p>
-        <ul className="text-[10px] text-muted-foreground list-disc pl-4 space-y-0.5">
-          <li><code className="bg-muted px-0.5 rounded">noauth</code> — skip JWT verification for this backend</li>
-          <li><code className="bg-muted px-0.5 rounded">eddsa</code> — passwordless RDP using EdDSA certificates</li>
-          <li><code className="bg-muted px-0.5 rounded">stripauth</code> — remove auth headers before forwarding to backend</li>
-        </ul>
-      </div>
+      <BackendsEditor
+        value={form.backends || ""}
+        onChange={(backends) => setForm({ ...form, backends })}
+      />
 
       <div className="space-y-1">
         <Label className="text-xs">Punchd Client TideCloak Config</Label>
@@ -388,6 +511,17 @@ export default function AdminGateways() {
                       </TableCell>
                       <TableCell className="text-right">
                         <div className="flex items-center justify-end gap-1">
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            title="Push config to the running gateway"
+                            disabled={pushMutation.isPending}
+                            onClick={() => pushMutation.mutate(config.id)}
+                          >
+                            {pushMutation.isPending && pushMutation.variables === config.id
+                              ? <Loader2 className="h-4 w-4 animate-spin" />
+                              : <UploadCloud className="h-4 w-4" />}
+                          </Button>
                           <Button size="icon" variant="ghost" title="Download gateway.toml" onClick={() => handleDownload(config)}>
                             <Download className="h-4 w-4" />
                           </Button>

--- a/server/lib/gatewayPush.ts
+++ b/server/lib/gatewayPush.ts
@@ -1,0 +1,163 @@
+import type { GatewayConfig } from "../storage";
+import type { SignalServer } from "@shared/schema";
+
+/**
+ * Config push: deliver a gateway's settings to the running gateway instead of
+ * making someone copy gateway.toml onto the box.
+ *
+ * The console POSTs to the signal server, which forwards the payload down the
+ * gateway's existing WebSocket; the gateway writes gateway.toml and reloads.
+ */
+
+export interface RejectedField {
+  field: string;
+  reason: string;
+}
+
+export interface GatewayPushResult {
+  /** The gateway received and acknowledged the push. */
+  delivered: boolean;
+  /** Gateway was offline — the signal server is holding the config for it. */
+  pending: boolean;
+  /** Fields whose value actually changed on the gateway. */
+  applied: string[];
+  /** Fields the gateway refused, with why. */
+  rejected: RejectedField[];
+  /** False when the gateway was already in the requested state. */
+  changed: boolean;
+  /** Set when the push could not be completed. */
+  error?: string | null;
+  /** Human-readable status for the console. */
+  message?: string;
+}
+
+/**
+ * Fields that are never pushed, because the gateway refuses them anyway.
+ *
+ * `tidecloak*` / `auth_server_public_url` decide which TideCloak the gateway
+ * trusts, and `gateway_id` / `stun_server_url` / `api_secret` are its identity
+ * and bootstrap. Sending them would only produce rejections — the gateway's own
+ * allowlist is the actual enforcement point (see PROTECTED_FIELDS in config.rs).
+ */
+export const NEVER_PUSHED = [
+  "gateway_id",
+  "stun_server_url",
+  "api_secret",
+  "tidecloak_config_b64",
+  "tidecloak_config_path",
+  "auth_server_public_url",
+  "tc_internal_url",
+] as const;
+
+/**
+ * Map a stored gateway config to the snake_case gateway.toml keys the gateway
+ * accepts. ICE/TURN fall back to the signal server's values, matching how
+ * `toToml` renders the downloadable file.
+ */
+export function buildPushPayload(
+  config: GatewayConfig,
+  signalServer?: SignalServer | null
+): Record<string, unknown> {
+  const ss = signalServer as (SignalServer & { iceServers?: string; turnServer?: string; turnSecret?: string }) | null | undefined;
+
+  const payload: Record<string, unknown> = {
+    backends: config.backends ?? null,
+    display_name: config.displayName ?? null,
+    ice_servers: config.iceServers || ss?.iceServers || null,
+    turn_server: config.turnServer || ss?.turnServer || null,
+    turn_secret: config.turnSecret || ss?.turnSecret || null,
+    server_url: config.serverUrl ?? null,
+    listen_port: config.listenPort,
+    health_port: config.healthPort,
+    https: config.https,
+    tls_hostname: config.tlsHostname,
+  };
+
+  // Drop keys with no value rather than pushing nulls that would clear settings
+  // the gateway may legitimately hold locally. An explicit empty string still
+  // clears a field, which is how the console removes a TURN server.
+  for (const [key, value] of Object.entries(payload)) {
+    if (value === null || value === undefined) delete payload[key];
+  }
+  return payload;
+}
+
+/** Find the signal server a gateway config points at. */
+export function matchSignalServer(
+  config: GatewayConfig,
+  signalServers: SignalServer[]
+): SignalServer | undefined {
+  return signalServers.find((ss) => {
+    const wsUrl = ss.url.replace(/^http/, "ws");
+    return config.stunServerUrl === ss.url || config.stunServerUrl === wsUrl;
+  });
+}
+
+/**
+ * Push a config to its gateway via the signal server.
+ *
+ * Never throws — a gateway being unreachable is an expected outcome that the
+ * console renders, not an error that should fail the surrounding save.
+ */
+export async function pushGatewayConfig(
+  config: GatewayConfig,
+  signalServer: SignalServer | undefined | null,
+  options: { fetchImpl?: typeof fetch; timeoutMs?: number } = {}
+): Promise<GatewayPushResult> {
+  const failure = (message: string): GatewayPushResult => ({
+    delivered: false,
+    pending: false,
+    applied: [],
+    rejected: [],
+    changed: false,
+    error: message,
+    message,
+  });
+
+  if (!signalServer) {
+    return failure("No signal server matches this gateway's STUN URL");
+  }
+
+  const secret = (signalServer as SignalServer & { apiSecret?: string }).apiSecret || config.apiSecret || "";
+  // The signal server derives its HTTP base from the same URL used for signaling.
+  const base = signalServer.url.replace(/^ws/, "http").replace(/\/$/, "");
+  const url = `${base}/api/gateways/${encodeURIComponent(config.gatewayId)}/config`;
+
+  const doFetch = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 20000);
+
+  try {
+    const resp = await doFetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-api-secret": secret },
+      body: JSON.stringify(buildPushPayload(config, signalServer)),
+      signal: controller.signal,
+    });
+
+    const body = (await resp.json().catch(() => ({}))) as Partial<GatewayPushResult> & { error?: string };
+
+    if (!resp.ok && resp.status !== 202) {
+      return failure(body.error || `Signal server returned ${resp.status}`);
+    }
+
+    return {
+      delivered: body.delivered ?? false,
+      pending: body.pending ?? false,
+      applied: body.applied ?? [],
+      rejected: body.rejected ?? [],
+      changed: body.changed ?? false,
+      error: body.error ?? null,
+      message: body.message,
+    };
+  } catch (e) {
+    const reason = e instanceof Error && e.name === "AbortError"
+      ? "Signal server did not respond in time"
+      : e instanceof Error
+        ? e.message
+        : String(e);
+    return failure(reason);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -139,6 +139,7 @@ import type { ChangeSetRequest, AccessApproval } from "./lib/auth/keycloakTypes"
 import { getAllowedSshUsersFromToken } from "./lib/auth/sshUsers";
 import { parseDestRolesFromToken, hasDestAccess } from "./lib/auth/destRoles";
 import { verifyTideCloakToken } from "./lib/auth/tideJWT";
+import { pushGatewayConfig, matchSignalServer } from "./lib/gatewayPush";
 
 // SSH connections are handled via WebSocket TCP bridge
 // The browser runs SSH client (using @microsoft/dev-tunnels-ssh)
@@ -1590,14 +1591,38 @@ export async function registerRoutes(
   });
 
   // PUT /api/admin/gateway-configs/:id - Update a gateway config
+  // Saving also pushes to the running gateway, so backends can be edited without
+  // copying gateway.toml onto the box. A gateway that is offline or unreachable
+  // still saves — the push result rides along in the response for the console.
   app.put("/api/admin/gateway-configs/:id", authenticate, requireAdminOrConfigDownload, async (req: AuthenticatedRequest, res) => {
     try {
       const config = await gatewayConfigStorage.update(req.params.id, req.body);
       if (!config) return res.status(404).json({ message: "Gateway config not found" });
-      res.json(config);
+
+      const signalServers = await signalServerStorage.getSignalServers();
+      const push = await pushGatewayConfig(config, matchSignalServer(config, signalServers));
+      if (push.error) log(`Gateway ${config.gatewayId} config push: ${push.error}`);
+
+      res.json({ ...config, push });
     } catch (error) {
       log(`Failed to update gateway config: ${error}`);
       res.status(500).json({ message: "Failed to update gateway config" });
+    }
+  });
+
+  // POST /api/admin/gateway-configs/:id/push - Re-push the stored config to its gateway
+  app.post("/api/admin/gateway-configs/:id/push", authenticate, requireAdminOrConfigDownload, async (req: AuthenticatedRequest, res) => {
+    try {
+      const config = await gatewayConfigStorage.getById(req.params.id);
+      if (!config) return res.status(404).json({ message: "Gateway config not found" });
+
+      const signalServers = await signalServerStorage.getSignalServers();
+      const push = await pushGatewayConfig(config, matchSignalServer(config, signalServers));
+      log(`[gateway-push] ${config.gatewayId} delivered=${push.delivered} pending=${push.pending} applied=${push.applied.join(",")}`);
+      res.json(push);
+    } catch (error) {
+      log(`Failed to push gateway config: ${error}`);
+      res.status(500).json({ message: "Failed to push gateway config" });
     }
   });
 
@@ -1715,14 +1740,24 @@ export async function registerRoutes(
           signalServerId: string;
           signalServerName: string;
           signalServerUrl: string;
+          issuer?: string | null;
         }> = [];
+
+        // A single signal server is shared across deployments (e.g. demo and
+        // devops), so only list gateways that trust this instance's TideCloak
+        // realm — gateways on another realm could never verify our tokens.
+        const ownIssuer = `${getAuthServerUrl().replace(/\/+$/, "")}/realms/${getRealm()}`;
+        const sameTenant = (issuer?: string | null) =>
+          // Gateways predating issuer advertisement report nothing — keep them
+          // visible so an in-progress rollout doesn't blank the list.
+          !issuer || issuer.replace(/\/+$/, "").toLowerCase() === ownIssuer.toLowerCase();
 
         // Fetch gateways from each signal server in parallel (with timeout)
         const fetches = enabledServers.map(async (ss) => {
           try {
             const controller = new AbortController();
             const timeout = setTimeout(() => controller.abort(), 5000);
-            const apiUrl = ss.url.replace(/\/$/, "") + "/api/gateways";
+            const apiUrl = ss.url.replace(/\/$/, "") + "/api/gateways?issuer=" + encodeURIComponent(ownIssuer);
             const resp = await fetch(apiUrl, { signal: controller.signal });
             clearTimeout(timeout);
             if (!resp.ok) return;
@@ -1733,9 +1768,12 @@ export async function registerRoutes(
               backends: { name: string; protocol?: string; auth?: string }[];
               online: boolean;
               clientCount: number;
+              issuer?: string | null;
             }> };
             if (data.gateways) {
               for (const gw of data.gateways) {
+                // Filter again locally: older signal servers ignore ?issuer=
+                if (!sameTenant(gw.issuer)) continue;
                 results.push({
                   ...gw,
                   backends: gw.backends || [],

--- a/signal-server-rs/src/http/routes.rs
+++ b/signal-server-rs/src/http/routes.rs
@@ -1,4 +1,8 @@
-use axum::{extract::State, response::Json};
+use axum::{
+    extract::{Query, State},
+    response::Json,
+};
+use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::http::turn::generate_turn_credentials;
@@ -55,12 +59,29 @@ pub async fn webrtc_config(State(state): State<AppState>) -> Json<Value> {
     Json(result)
 }
 
-pub async fn gateways(State(state): State<AppState>) -> Json<Value> {
+#[derive(Debug, Default, Deserialize)]
+pub struct GatewaysQuery {
+    /// Only return gateways trusting this TideCloak issuer. Gateways that do not
+    /// advertise an issuer (older builds) are always returned, so an in-progress
+    /// rollout never blanks a tenant's list.
+    pub issuer: Option<String>,
+}
+
+pub async fn gateways(
+    State(state): State<AppState>,
+    Query(query): Query<GatewaysQuery>,
+) -> Json<Value> {
+    let want_issuer = query.issuer.as_deref().map(|s| s.trim_end_matches('/'));
     let gateways: Vec<Value> = state.registry.get_all_gateways()
         .iter()
         .filter_map(|id| {
-            state.registry.get_gateway(id).map(|gw| {
-                json!({
+            state.registry.get_gateway(id).and_then(|gw| {
+                if let (Some(want), Some(have)) = (want_issuer, gw.metadata.issuer.as_deref()) {
+                    if !want.eq_ignore_ascii_case(have.trim_end_matches('/')) {
+                        return None;
+                    }
+                }
+                Some(json!({
                     "id": gw.id,
                     "displayName": gw.metadata.display_name,
                     "description": gw.metadata.description,
@@ -68,9 +89,390 @@ pub async fn gateways(State(state): State<AppState>) -> Json<Value> {
                     "addresses": gw.addresses,
                     "clientCount": gw.paired_clients.len(),
                     "online": true,
-                })
+                    "issuer": gw.metadata.issuer,
+                    "clientId": gw.metadata.client_id,
+                }))
             })
         })
         .collect();
     Json(json!({ "gateways": gateways }))
+}
+
+/// How long to wait for a gateway to confirm it applied a pushed config.
+const CONFIG_PUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Build the `config_update` frame sent down a gateway's WebSocket.
+pub fn config_update_message(request_id: &str, config: &Value) -> String {
+    json!({
+        "type": "config_update",
+        "requestId": request_id,
+        "config": config,
+    })
+    .to_string()
+}
+
+/// POST /api/gateways/{id}/config — push config to a gateway.
+///
+/// Authenticated with the same shared API secret gateways use to register, so
+/// no new credential is introduced. The gateway itself refuses any field that
+/// would change which TideCloak it trusts, which is what keeps this secret from
+/// being an authentication bypass.
+pub async fn push_gateway_config(
+    State(state): State<AppState>,
+    axum::extract::Path(gateway_id): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
+    Json(config): Json<Value>,
+) -> (axum::http::StatusCode, Json<Value>) {
+    use axum::http::StatusCode;
+
+    if !state.config.api_secret.is_empty() {
+        let presented = headers
+            .get("x-api-secret")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if presented != state.config.api_secret {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Invalid API secret" })),
+            );
+        }
+    }
+
+    if !config.is_object() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "Config must be a JSON object" })),
+        );
+    }
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+
+    // Offline gateway: hold the config and hand it over when it next registers.
+    if state.registry.get_gateway(&gateway_id).is_none() {
+        state.pending_configs.insert(gateway_id.clone(), config);
+        tracing::info!("[Signal] Gateway {gateway_id} offline — config queued for next registration");
+        return (
+            StatusCode::ACCEPTED,
+            Json(json!({
+                "delivered": false,
+                "pending": true,
+                "message": "Gateway offline — config queued for its next registration",
+            })),
+        );
+    }
+
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+    state.pending_config_acks.insert(request_id.clone(), ack_tx);
+
+    let sent = state.registry.send_to_gateway(
+        &gateway_id,
+        axum::extract::ws::Message::Text(config_update_message(&request_id, &config).into()),
+    );
+
+    if !sent {
+        state.pending_config_acks.remove(&request_id);
+        state.pending_configs.insert(gateway_id.clone(), config);
+        return (
+            StatusCode::ACCEPTED,
+            Json(json!({
+                "delivered": false,
+                "pending": true,
+                "message": "Gateway connection closed — config queued for its next registration",
+            })),
+        );
+    }
+
+    match tokio::time::timeout(CONFIG_PUSH_TIMEOUT, ack_rx).await {
+        Ok(Ok(ack)) => (
+            StatusCode::OK,
+            Json(json!({
+                "delivered": true,
+                "pending": false,
+                "applied": ack.get("applied").cloned().unwrap_or(json!([])),
+                "rejected": ack.get("rejected").cloned().unwrap_or(json!([])),
+                "changed": ack.get("changed").cloned().unwrap_or(json!(false)),
+                "error": ack.get("error").cloned().unwrap_or(Value::Null),
+            })),
+        ),
+        // Gateway dropped before acking.
+        Ok(Err(_)) => {
+            state.pending_config_acks.remove(&request_id);
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "delivered": false, "error": "Gateway disconnected before confirming" })),
+            )
+        }
+        Err(_) => {
+            state.pending_config_acks.remove(&request_id);
+            (
+                StatusCode::GATEWAY_TIMEOUT,
+                Json(json!({ "delivered": false, "error": "Gateway did not confirm within 15s" })),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::registry::GatewayMetadata;
+    use tokio::sync::mpsc;
+
+    fn state() -> AppState {
+        AppState::new(Config::from_env())
+    }
+
+    fn register(st: &AppState, id: &str, issuer: Option<&str>) {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let meta = GatewayMetadata {
+            display_name: None,
+            description: None,
+            backends: None,
+            realm: None,
+            issuer: issuer.map(|s| s.to_string()),
+            client_id: None,
+            public_url: None,
+        };
+        st.registry.register_gateway(id.into(), vec![], tx, meta, None);
+    }
+
+    fn ids(res: &Json<Value>) -> Vec<String> {
+        let mut v: Vec<String> = res["gateways"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|g| g["id"].as_str().unwrap().to_string())
+            .collect();
+        v.sort();
+        v
+    }
+
+    /// Register a gateway and keep its channel open so pushes can reach it.
+    fn register_live(st: &AppState, id: &str) -> mpsc::UnboundedReceiver<axum::extract::ws::Message> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let meta = GatewayMetadata {
+            display_name: None,
+            description: None,
+            backends: None,
+            realm: None,
+            issuer: None,
+            client_id: None,
+            public_url: None,
+        };
+        st.registry.register_gateway(id.into(), vec![], tx, meta, None);
+        rx
+    }
+
+    fn secured_state(secret: &str) -> AppState {
+        let mut config = Config::from_env();
+        config.api_secret = secret.to_string();
+        AppState::new(config)
+    }
+
+    fn secret_header(secret: &str) -> axum::http::HeaderMap {
+        let mut h = axum::http::HeaderMap::new();
+        h.insert("x-api-secret", secret.parse().unwrap());
+        h
+    }
+
+    const DEMO: &str = "https://tc.example.com/realms/demo";
+    const DEVOPS: &str = "https://tc.example.com/realms/devops";
+
+    #[tokio::test]
+    async fn no_issuer_query_returns_every_gateway() {
+        let st = state();
+        register(&st, "demo-gw", Some(DEMO));
+        register(&st, "devops-gw", Some(DEVOPS));
+
+        let res = gateways(State(st), Query(GatewaysQuery::default())).await;
+        assert_eq!(ids(&res), vec!["demo-gw", "devops-gw"]);
+    }
+
+    #[tokio::test]
+    async fn issuer_query_excludes_other_tenants() {
+        let st = state();
+        register(&st, "demo-gw", Some(DEMO));
+        register(&st, "devops-gw", Some(DEVOPS));
+
+        let q = GatewaysQuery { issuer: Some(DEMO.into()) };
+        let res = gateways(State(st), Query(q)).await;
+        assert_eq!(ids(&res), vec!["demo-gw"]);
+    }
+
+    #[tokio::test]
+    async fn trailing_slash_and_case_do_not_split_a_tenant() {
+        let st = state();
+        register(&st, "demo-gw", Some("https://TC.example.com/realms/demo/"));
+
+        let q = GatewaysQuery { issuer: Some(DEMO.into()) };
+        let res = gateways(State(st), Query(q)).await;
+        assert_eq!(ids(&res), vec!["demo-gw"]);
+    }
+
+    #[tokio::test]
+    async fn gateways_without_an_issuer_stay_visible() {
+        let st = state();
+        register(&st, "legacy-gw", None);
+        register(&st, "devops-gw", Some(DEVOPS));
+
+        let q = GatewaysQuery { issuer: Some(DEMO.into()) };
+        let res = gateways(State(st), Query(q)).await;
+        assert_eq!(ids(&res), vec!["legacy-gw"]);
+    }
+
+    #[tokio::test]
+    async fn issuer_is_exposed_to_consoles() {
+        let st = state();
+        register(&st, "demo-gw", Some(DEMO));
+
+        let res = gateways(State(st), Query(GatewaysQuery::default())).await;
+        assert_eq!(res["gateways"][0]["issuer"].as_str(), Some(DEMO));
+    }
+
+    // ── Config push ──────────────────────────────────────────────
+
+    use axum::extract::Path;
+    use axum::http::StatusCode;
+
+    #[tokio::test]
+    async fn push_requires_the_api_secret() {
+        let st = secured_state("correct-secret");
+        register_live(&st, "gw-1");
+
+        let (status, body) = push_gateway_config(
+            State(st.clone()),
+            Path("gw-1".into()),
+            secret_header("wrong-secret"),
+            Json(json!({ "backends": "App=http://10.0.0.5:8080" })),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["error"].as_str(), Some("Invalid API secret"));
+        assert!(st.pending_configs.is_empty(), "a rejected push must not be queued");
+    }
+
+    #[tokio::test]
+    async fn push_rejects_a_non_object_body() {
+        let st = state();
+        register_live(&st, "gw-1");
+
+        let (status, _) = push_gateway_config(
+            State(st),
+            Path("gw-1".into()),
+            axum::http::HeaderMap::new(),
+            Json(json!("not-an-object")),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn push_to_an_offline_gateway_is_queued() {
+        let st = state();
+
+        let (status, body) = push_gateway_config(
+            State(st.clone()),
+            Path("never-connected".into()),
+            axum::http::HeaderMap::new(),
+            Json(json!({ "backends": "App=http://10.0.0.5:8080" })),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(body["pending"].as_bool(), Some(true));
+        assert_eq!(body["delivered"].as_bool(), Some(false));
+        let queued = st.pending_configs.get("never-connected").expect("config queued");
+        assert_eq!(queued["backends"].as_str(), Some("App=http://10.0.0.5:8080"));
+    }
+
+    #[tokio::test]
+    async fn a_newer_queued_push_supersedes_the_older_one() {
+        let st = state();
+        for backends in ["App=http://old:8080", "App=http://new:8080"] {
+            push_gateway_config(
+                State(st.clone()),
+                Path("offline-gw".into()),
+                axum::http::HeaderMap::new(),
+                Json(json!({ "backends": backends })),
+            )
+            .await;
+        }
+
+        assert_eq!(st.pending_configs.len(), 1);
+        let queued = st.pending_configs.get("offline-gw").unwrap();
+        assert_eq!(queued["backends"].as_str(), Some("App=http://new:8080"));
+    }
+
+    #[tokio::test]
+    async fn push_delivers_to_an_online_gateway_and_returns_its_ack() {
+        let st = secured_state("s3cret");
+        let mut rx = register_live(&st, "gw-1");
+
+        // Stand in for the gateway: read the frame, ack what it applied.
+        let acking = tokio::spawn({
+            let st = st.clone();
+            async move {
+                let msg = rx.recv().await.expect("gateway receives the push");
+                let text = match msg {
+                    axum::extract::ws::Message::Text(t) => t.to_string(),
+                    other => panic!("expected a text frame, got {other:?}"),
+                };
+                let frame: Value = serde_json::from_str(&text).unwrap();
+                assert_eq!(frame["type"].as_str(), Some("config_update"));
+                assert_eq!(frame["config"]["backends"].as_str(), Some("App=http://10.0.0.5:8080"));
+
+                let request_id = frame["requestId"].as_str().unwrap().to_string();
+                let (_, ack_tx) = st.pending_config_acks.remove(&request_id).expect("ack registered");
+                ack_tx
+                    .send(json!({
+                        "applied": ["backends"],
+                        "rejected": [{ "field": "api_secret", "reason": "set locally on the gateway only" }],
+                        "changed": true,
+                    }))
+                    .unwrap();
+            }
+        });
+
+        let (status, body) = push_gateway_config(
+            State(st.clone()),
+            Path("gw-1".into()),
+            secret_header("s3cret"),
+            Json(json!({ "backends": "App=http://10.0.0.5:8080", "api_secret": "nope" })),
+        )
+        .await;
+
+        acking.await.unwrap();
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["delivered"].as_bool(), Some(true));
+        assert_eq!(body["changed"].as_bool(), Some(true));
+        assert_eq!(body["applied"][0].as_str(), Some("backends"));
+        assert_eq!(body["rejected"][0]["field"].as_str(), Some("api_secret"));
+        assert!(st.pending_config_acks.is_empty(), "the ack slot must be cleaned up");
+        assert!(st.pending_configs.is_empty(), "a delivered push must not also queue");
+    }
+
+    #[tokio::test]
+    async fn push_to_a_closed_connection_falls_back_to_queueing() {
+        let st = state();
+        // Registered, but the receiving end is gone — a gateway that dropped
+        // without the registry noticing yet.
+        let rx = register_live(&st, "gw-1");
+        drop(rx);
+
+        let (status, body) = push_gateway_config(
+            State(st.clone()),
+            Path("gw-1".into()),
+            axum::http::HeaderMap::new(),
+            Json(json!({ "backends": "App=http://10.0.0.5:8080" })),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(body["pending"].as_bool(), Some(true));
+        assert!(st.pending_configs.contains_key("gw-1"));
+        assert!(st.pending_config_acks.is_empty(), "the ack slot must be cleaned up");
+    }
 }

--- a/signal-server-rs/src/main.rs
+++ b/signal-server-rs/src/main.rs
@@ -7,7 +7,7 @@ mod proxy;
 mod quic;
 mod http;
 
-use axum::{routing::get, Router};
+use axum::{routing::{get, post}, Router};
 use axum::http::Request;
 use axum::middleware::Next;
 use axum::response::Response;
@@ -59,6 +59,7 @@ async fn main() {
         .route("/health", get(http::routes::health))
         .route("/webrtc-config", get(http::routes::webrtc_config))
         .route("/api/gateways", get(http::routes::gateways))
+        .route("/api/gateways/{id}/config", post(http::routes::push_gateway_config))
         .route("/ws/ssh", get(proxy::ssh::ssh_ws_handler))
         // WebSocket signaling on root path
         .route("/", get(signaling::handler::ws_handler))

--- a/signal-server-rs/src/registry/mod.rs
+++ b/signal-server-rs/src/registry/mod.rs
@@ -15,6 +15,13 @@ pub struct GatewayMetadata {
     pub backends: Option<Vec<BackendInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub realm: Option<String>,
+    /// TideCloak issuer this gateway trusts (`<auth-server-url>/realms/<realm>`).
+    /// Descriptive only — unlike `realm` it is always advertised, so it can be
+    /// used to tell tenants apart without affecting HTTP relay routing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub public_url: Option<String>,
 }
@@ -235,6 +242,8 @@ mod tests {
             description: None,
             backends: None,
             realm: None,
+            issuer: None,
+            client_id: None,
             public_url: None,
         }
     }
@@ -255,6 +264,8 @@ mod tests {
             description: Some("Test gateway".into()),
             backends: Some(vec![BackendInfo { name: "App".into(), protocol: Some("http".into()), auth: None }]),
             realm: Some("keylessh".into()),
+            issuer: Some("https://tc.example.com/realms/keylessh".into()),
+            client_id: Some("punchd".into()),
             public_url: None,
         };
         r.register_gateway("gw-1".into(), vec!["1.2.3.4:443".into()], sender(), m, None);
@@ -263,6 +274,8 @@ mod tests {
         assert_eq!(gw.metadata.description.as_deref(), Some("Test gateway"));
         assert_eq!(gw.metadata.backends.as_ref().unwrap().len(), 1);
         assert_eq!(gw.metadata.realm.as_deref(), Some("keylessh"));
+        assert_eq!(gw.metadata.issuer.as_deref(), Some("https://tc.example.com/realms/keylessh"));
+        assert_eq!(gw.metadata.client_id.as_deref(), Some("punchd"));
     }
 
     #[test]

--- a/signal-server-rs/src/signaling/handler.rs
+++ b/signal-server-rs/src/signaling/handler.rs
@@ -100,6 +100,8 @@ async fn handle_signaling(socket: WebSocket, client_ip: String, state: AppState)
                                     }).collect()
                                 }),
                                 realm: parsed["metadata"]["realm"].as_str().map(|s| s.to_string()),
+                                issuer: parsed["metadata"]["issuer"].as_str().map(|s| s.trim_end_matches('/').to_string()),
+                                client_id: parsed["metadata"]["clientId"].as_str().map(|s| s.to_string()),
                                 public_url: parsed["metadata"]["publicUrl"].as_str().map(|s| s.to_string()),
                             };
 
@@ -118,6 +120,17 @@ async fn handle_signaling(socket: WebSocket, client_ip: String, state: AppState)
                             let _ = tx.send(Message::Text(
                                 serde_json::json!({"type": "registered", "role": "gateway", "id": id}).to_string().into()
                             ));
+
+                            // Hand over any config pushed while this gateway was
+                            // offline. Removed on send: if the gateway drops again
+                            // before applying it, the console's next push re-queues it.
+                            if let Some((_, config)) = state.pending_configs.remove(&id) {
+                                let request_id = uuid::Uuid::new_v4().to_string();
+                                tracing::info!("[Signal] Delivering queued config to gateway {id}");
+                                let _ = tx.send(Message::Text(
+                                    crate::http::routes::config_update_message(&request_id, &config).into()
+                                ));
+                            }
                         } else if role == "client" {
                             let token = parsed["token"].as_str().unwrap_or("").to_string();
                             tracing::info!("[Signal] Client registered: {id}");
@@ -239,6 +252,22 @@ async fn handle_signaling(socket: WebSocket, client_ip: String, state: AppState)
                     }
                     "punch" => {
                         // Forwarded internally — not expected from external clients
+                    }
+                    "config_ack" => {
+                        // Gateway confirming a pushed config. Hand the result to
+                        // whichever HTTP caller is still waiting on it.
+                        let req_id = parsed["requestId"].as_str().unwrap_or("").to_string();
+                        if let Some((_, ack_tx)) = state.pending_config_acks.remove(&req_id) {
+                            let _ = ack_tx.send(parsed.clone());
+                        } else {
+                            // Queued push applied after reconnect — nobody is waiting.
+                            tracing::info!(
+                                "[Signal] Config ack from {}: applied={} rejected={}",
+                                parsed["gatewayId"].as_str().unwrap_or("?"),
+                                parsed["applied"],
+                                parsed["rejected"],
+                            );
+                        }
                     }
                     "http_response" | "http_response_start" | "http_response_chunk" | "http_response_end" | "http_abort" => {
                         let req_id = parsed["id"].as_str().unwrap_or("").to_string();
@@ -402,6 +431,8 @@ mod tests {
             description: None,
             backends: None,
             realm: None,
+            issuer: None,
+            client_id: None,
             public_url: None,
         }
     }

--- a/signal-server-rs/src/state.rs
+++ b/signal-server-rs/src/state.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::config::Config;
 use crate::registry::Registry;
@@ -36,6 +36,12 @@ pub struct AppState {
     pub registry: Arc<Registry>,
     pub pending_requests: Arc<DashMap<String, PendingRequest>>,
     pub connections_by_ip: Arc<DashMap<String, usize>>,
+    /// In-flight config pushes, keyed by request id, awaiting the gateway's ack.
+    pub pending_config_acks: Arc<DashMap<String, oneshot::Sender<serde_json::Value>>>,
+    /// Config pushed to a gateway that was offline, keyed by gateway id, and
+    /// delivered when it next registers. Only the newest push per gateway is
+    /// kept — an older one has already been superseded.
+    pub pending_configs: Arc<DashMap<String, serde_json::Value>>,
 }
 
 impl AppState {
@@ -45,6 +51,8 @@ impl AppState {
             registry: Arc::new(Registry::new()),
             pending_requests: Arc::new(DashMap::new()),
             connections_by_ip: Arc::new(DashMap::new()),
+            pending_config_acks: Arc::new(DashMap::new()),
+            pending_configs: Arc::new(DashMap::new()),
         }
     }
 }

--- a/tests/client/backends.test.ts
+++ b/tests/client/backends.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @fileoverview Tests for the gateway backends DSL used by the console editor.
+ *
+ * The format (`Name=url;flag;flag, Name=url`) is parsed by the gateway in
+ * parse_backends_str; these tests pin the console's parse/serialize to it.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseBackends,
+  serializeBackends,
+  backendProtocol,
+  type BackendRow,
+} from "../../client/src/lib/backends";
+
+describe("backendProtocol", () => {
+  it("detects rdp, ssh, and defaults to http", () => {
+    expect(backendProtocol("rdp://10.0.0.9:3389")).toBe("rdp");
+    expect(backendProtocol("ssh://10.0.0.9:22")).toBe("ssh");
+    expect(backendProtocol("http://10.0.0.9:8080")).toBe("http");
+    expect(backendProtocol("https://app.internal")).toBe("http");
+  });
+
+  it("is case insensitive and ignores surrounding space", () => {
+    expect(backendProtocol("  RDP://10.0.0.9:3389 ")).toBe("rdp");
+  });
+});
+
+describe("parseBackends", () => {
+  it("returns nothing for empty input", () => {
+    expect(parseBackends("")).toEqual([]);
+    expect(parseBackends(null)).toEqual([]);
+    expect(parseBackends(undefined)).toEqual([]);
+  });
+
+  it("parses a single backend", () => {
+    expect(parseBackends("App=http://10.0.0.5:8080")).toEqual([
+      { name: "App", url: "http://10.0.0.5:8080", noAuth: false, stripAuth: false, eddsa: false },
+    ]);
+  });
+
+  it("parses several backends with surrounding space", () => {
+    const rows = parseBackends("App=http://10.0.0.5:8080, Desk = rdp://10.0.0.9:3389 ");
+
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toMatchObject({ name: "Desk", url: "rdp://10.0.0.9:3389" });
+  });
+
+  it("parses flags in any order and combination", () => {
+    const rows = parseBackends("A=rdp://h:3389;eddsa, B=http://h:80;noauth;stripauth");
+
+    expect(rows[0]).toMatchObject({ eddsa: true, noAuth: false, stripAuth: false });
+    expect(rows[1]).toMatchObject({ noAuth: true, stripAuth: true, eddsa: false });
+    expect(rows[0].url).toBe("rdp://h:3389");
+    expect(rows[1].url).toBe("http://h:80");
+  });
+
+  it("is case insensitive on flags", () => {
+    expect(parseBackends("A=rdp://h:3389;EdDSA")[0]).toMatchObject({ eddsa: true, url: "rdp://h:3389" });
+  });
+
+  it("tolerates trailing semicolons", () => {
+    expect(parseBackends("A=http://h:80;;")[0].url).toBe("http://h:80");
+  });
+
+  it("drops entries the gateway would refuse", () => {
+    expect(parseBackends("no-equals-sign")).toEqual([]);
+    expect(parseBackends("A=")).toEqual([]);
+    expect(parseBackends("=http://h:80")).toEqual([]);
+  });
+
+  it("keeps the valid entries alongside a malformed one", () => {
+    const rows = parseBackends("Good=http://h:80, garbage, Also=ssh://h:22");
+
+    expect(rows.map((r) => r.name)).toEqual(["Good", "Also"]);
+  });
+});
+
+describe("serializeBackends", () => {
+  const row = (over: Partial<BackendRow> = {}): BackendRow => ({
+    name: "App",
+    url: "http://10.0.0.5:8080",
+    noAuth: false,
+    stripAuth: false,
+    eddsa: false,
+    ...over,
+  });
+
+  it("renders name=url pairs", () => {
+    expect(serializeBackends([row()])).toBe("App=http://10.0.0.5:8080");
+  });
+
+  it("appends set flags", () => {
+    expect(serializeBackends([row({ url: "rdp://h:3389", eddsa: true })])).toBe("App=rdp://h:3389;eddsa");
+    expect(serializeBackends([row({ noAuth: true, stripAuth: true })])).toBe(
+      "App=http://10.0.0.5:8080;noauth;stripauth"
+    );
+  });
+
+  it("joins multiple backends with a comma", () => {
+    expect(serializeBackends([row(), row({ name: "Desk", url: "rdp://h:3389" })])).toBe(
+      "App=http://10.0.0.5:8080, Desk=rdp://h:3389"
+    );
+  });
+
+  it("skips rows the user has not filled in", () => {
+    expect(serializeBackends([row(), row({ name: "", url: "" }), row({ name: "Half", url: "" })])).toBe(
+      "App=http://10.0.0.5:8080"
+    );
+  });
+
+  it("trims whitespace the user typed", () => {
+    expect(serializeBackends([row({ name: "  App  ", url: "  http://h:80  " })])).toBe("App=http://h:80");
+  });
+
+  it("returns an empty string for no rows", () => {
+    expect(serializeBackends([])).toBe("");
+  });
+});
+
+describe("round trip", () => {
+  it("preserves a config through parse and serialize", () => {
+    const original = "App=http://10.0.0.5:8080, Desk=rdp://10.0.0.9:3389;eddsa, Shell=ssh://10.0.0.3:22;noauth";
+
+    expect(serializeBackends(parseBackends(original))).toBe(original);
+  });
+
+  it("normalizes spacing without changing meaning", () => {
+    const messy = "App = http://10.0.0.5:8080 ,Desk=rdp://10.0.0.9:3389;eddsa";
+
+    const normalized = serializeBackends(parseBackends(messy));
+    expect(normalized).toBe("App=http://10.0.0.5:8080, Desk=rdp://10.0.0.9:3389;eddsa");
+    expect(parseBackends(normalized)).toEqual(parseBackends(messy));
+  });
+});

--- a/tests/server/gatewayPush.test.ts
+++ b/tests/server/gatewayPush.test.ts
@@ -1,0 +1,248 @@
+/**
+ * @fileoverview Tests for pushing gateway config to a running gateway.
+ *
+ * Covers buildPushPayload() (which fields leave the console), matchSignalServer()
+ * and pushGatewayConfig() (delivery, queueing, and failure handling).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildPushPayload,
+  matchSignalServer,
+  pushGatewayConfig,
+  NEVER_PUSHED,
+} from "../../server/lib/gatewayPush";
+import type { GatewayConfig } from "../../server/storage";
+import type { SignalServer } from "@shared/schema";
+
+function gatewayConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    id: "cfg-1",
+    gatewayId: "gw-1",
+    displayName: "Demo Gateway",
+    stunServerUrl: "wss://signal.example.com",
+    apiSecret: "gateway-secret",
+    iceServers: "stun:1.2.3.4:3478",
+    turnServer: "turn:1.2.3.4:3478",
+    turnSecret: "turn-secret",
+    backends: "App=http://10.0.0.5:8080",
+    tidecloakConfigB64: "ZXhpc3Rpbmc=",
+    authServerPublicUrl: "https://tc.example.com",
+    serverUrl: "https://console.example.com",
+    vpnEnabled: false,
+    vpnSubnet: "10.66.0.0/24",
+    listenPort: 7891,
+    healthPort: 7892,
+    https: true,
+    tlsHostname: "gw.example.com",
+    extraConfig: null,
+    directUrl: null,
+    enabled: true,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function signalServer(overrides: Partial<SignalServer> = {}): SignalServer {
+  return {
+    id: "ss-1",
+    name: "Shared Signal",
+    url: "https://signal.example.com",
+    description: null,
+    enabled: true,
+    createdAt: new Date(0),
+    apiSecret: "signal-secret",
+    iceServers: null,
+    turnServer: null,
+    turnSecret: null,
+    ...overrides,
+  } as SignalServer;
+}
+
+describe("buildPushPayload", () => {
+  it("maps stored config to gateway.toml keys", () => {
+    const payload = buildPushPayload(gatewayConfig());
+
+    expect(payload).toMatchObject({
+      backends: "App=http://10.0.0.5:8080",
+      display_name: "Demo Gateway",
+      ice_servers: "stun:1.2.3.4:3478",
+      turn_server: "turn:1.2.3.4:3478",
+      listen_port: 7891,
+      health_port: 7892,
+      https: true,
+      tls_hostname: "gw.example.com",
+      server_url: "https://console.example.com",
+    });
+  });
+
+  it("never sends the TideCloak trust anchor or gateway identity", () => {
+    const payload = buildPushPayload(gatewayConfig(), signalServer());
+
+    for (const field of NEVER_PUSHED) {
+      expect(payload).not.toHaveProperty(field);
+    }
+    // Nor their camelCase spellings, in case a rename slips through.
+    expect(payload).not.toHaveProperty("tidecloakConfigB64");
+    expect(payload).not.toHaveProperty("authServerPublicUrl");
+    expect(payload).not.toHaveProperty("apiSecret");
+    expect(payload).not.toHaveProperty("gatewayId");
+  });
+
+  it("falls back to the signal server for ICE/TURN", () => {
+    const config = gatewayConfig({ iceServers: null, turnServer: null, turnSecret: null });
+    const ss = signalServer({
+      iceServers: "stun:9.9.9.9:3478",
+      turnServer: "turn:9.9.9.9:3478",
+      turnSecret: "inherited",
+    } as Partial<SignalServer>);
+
+    const payload = buildPushPayload(config, ss);
+
+    expect(payload.ice_servers).toBe("stun:9.9.9.9:3478");
+    expect(payload.turn_server).toBe("turn:9.9.9.9:3478");
+    expect(payload.turn_secret).toBe("inherited");
+  });
+
+  it("omits unset fields rather than pushing nulls", () => {
+    const payload = buildPushPayload(gatewayConfig({ backends: null, serverUrl: null }));
+
+    expect(payload).not.toHaveProperty("backends");
+    expect(payload).not.toHaveProperty("server_url");
+  });
+
+  it("keeps an explicit empty string so a field can be cleared", () => {
+    const payload = buildPushPayload(gatewayConfig({ backends: "" }), signalServer());
+
+    expect(payload.backends).toBe("");
+  });
+});
+
+describe("matchSignalServer", () => {
+  it("matches on the ws form of the signal server URL", () => {
+    const config = gatewayConfig({ stunServerUrl: "wss://signal.example.com" });
+    expect(matchSignalServer(config, [signalServer()])?.id).toBe("ss-1");
+  });
+
+  it("matches on the http form too", () => {
+    const config = gatewayConfig({ stunServerUrl: "https://signal.example.com" });
+    expect(matchSignalServer(config, [signalServer()])?.id).toBe("ss-1");
+  });
+
+  it("returns undefined when nothing matches", () => {
+    const config = gatewayConfig({ stunServerUrl: "wss://other.example.com" });
+    expect(matchSignalServer(config, [signalServer()])).toBeUndefined();
+  });
+});
+
+describe("pushGatewayConfig", () => {
+  it("posts to the signal server with its API secret", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ delivered: true, applied: ["backends"], rejected: [], changed: true }),
+    });
+
+    const result = await pushGatewayConfig(gatewayConfig(), signalServer(), { fetchImpl: fetchImpl as any });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe("https://signal.example.com/api/gateways/gw-1/config");
+    expect(init.method).toBe("POST");
+    expect(init.headers["x-api-secret"]).toBe("signal-secret");
+    expect(result.delivered).toBe(true);
+    expect(result.applied).toEqual(["backends"]);
+  });
+
+  it("derives an http base from a ws signal server URL", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ delivered: true }) });
+
+    await pushGatewayConfig(gatewayConfig(), signalServer({ url: "wss://signal.example.com/" }), {
+      fetchImpl: fetchImpl as any,
+    });
+
+    expect(fetchImpl.mock.calls[0][0]).toBe("https://signal.example.com/api/gateways/gw-1/config");
+  });
+
+  it("reports a queued push for an offline gateway", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 202,
+      json: async () => ({ delivered: false, pending: true, message: "Gateway offline — config queued" }),
+    });
+
+    const result = await pushGatewayConfig(gatewayConfig(), signalServer(), { fetchImpl: fetchImpl as any });
+
+    expect(result.pending).toBe(true);
+    expect(result.delivered).toBe(false);
+    expect(result.error).toBeNull();
+    expect(result.message).toContain("queued");
+  });
+
+  it("surfaces fields the gateway refused", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        delivered: true,
+        changed: true,
+        applied: ["backends"],
+        rejected: [{ field: "api_secret", reason: "set locally on the gateway only" }],
+      }),
+    });
+
+    const result = await pushGatewayConfig(gatewayConfig(), signalServer(), { fetchImpl: fetchImpl as any });
+
+    expect(result.rejected).toEqual([{ field: "api_secret", reason: "set locally on the gateway only" }]);
+  });
+
+  it("fails cleanly when no signal server matches", async () => {
+    const result = await pushGatewayConfig(gatewayConfig(), undefined);
+
+    expect(result.delivered).toBe(false);
+    expect(result.error).toContain("No signal server");
+  });
+
+  it("does not throw when the signal server is unreachable", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const result = await pushGatewayConfig(gatewayConfig(), signalServer(), { fetchImpl: fetchImpl as any });
+
+    expect(result.delivered).toBe(false);
+    expect(result.error).toBe("ECONNREFUSED");
+  });
+
+  it("reports an error status from the signal server", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "Invalid API secret" }),
+    });
+
+    const result = await pushGatewayConfig(gatewayConfig(), signalServer(), { fetchImpl: fetchImpl as any });
+
+    expect(result.delivered).toBe(false);
+    expect(result.error).toBe("Invalid API secret");
+  });
+
+  it("times out rather than hanging on a silent signal server", async () => {
+    const fetchImpl = vi.fn().mockImplementation((_url: string, init: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      })
+    );
+
+    const result = await pushGatewayConfig(gatewayConfig(), signalServer(), {
+      fetchImpl: fetchImpl as any,
+      timeoutMs: 10,
+    });
+
+    expect(result.delivered).toBe(false);
+    expect(result.error).toContain("did not respond in time");
+  });
+});


### PR DESCRIPTION
## Summary

Three related pieces of work on the gateway/VPN stack.

### Per-tenant gateway lists

A signal server shared between deployments (demo and devops) showed every deployment's gateways in every console. Gateways now advertise the TideCloak issuer they trust, taken from their `tidecloak.json`, and the console lists only gateways matching its own realm. Those entries could never have connected anyway — a gateway on another realm cannot verify this console's tokens.

Advertised unconditionally and kept separate from the existing `realm` metadata, which doubles as the HTTP relay routing key. Gateways that predate the field stay visible so an in-progress rollout does not blank a tenant's list.

### Remote gateway config

Editing backends no longer means copying `gateway.toml` onto the box. Saving in the console pushes to the running gateway: keylessh posts to the signal server, which forwards a `config_update` over the gateway's existing WebSocket; the gateway writes the file and reloads. Offline gateways get the config queued and delivered on next registration. The console reports what the gateway actually applied, not just that the save succeeded.

**The TideCloak trust anchor is never pushed** — `tidecloak_config_*`, `auth_server_public_url`, `tc_internal_url`, plus `gateway_id` / `stun_server_url` / `api_secret`. The signal server's API secret is a single shared server-wide value, so a pushable trust anchor would let anyone holding it repoint a gateway at their own IdP and mint access to every backend behind it. Enforced twice: the console omits those fields, and the gateway refuses them.

Backends are now edited as rows — name, URL, protocol badge, flag checkboxes — with a toggle back to the raw `Name=url;flags` string.

Two decisions worth flagging for review:

- The push triggers the gateway's reload callback directly instead of relying on the file watcher, which follows an inode that the atomic rename replaces — it would have caught the first push and gone deaf to every one after.
- Rewriting `gateway.toml` serializes from the known schema, so comments and unrecognized keys in a hand-edited file are dropped on first push. The file gets a header saying it is console-managed.

### VPN client auth

Two bugs, both about the login window:

- **Started without ever prompting to sign in.** WebView storage survives restarts, so the previous session's expired token was reported as the initial token; Rust accepted it, hid the window, and the connection then failed against the gateway. Tokens are now checked for remaining life in three places, with 30s of headroom so a connection does not start with one that dies mid-handshake.
- **Refresh never prompted for credentials.** The tray handler was a no-op, and since the window is hidden after first login there was no path back to a visible prompt — a failed refresh redirected to a login page inside an invisible window. The page now reports when it needs auth and the window is brought back up.

### MSI build

`release.yml` hardcoded a Visual Studio Enterprise path that no longer exists on the runner, so `VsDevCmd.bat` silently did not run and the step failed with `'cl' is not recognized`. Now located with `vswhere`, plus explicit checks so a future mismatch reports the real problem.

## Testing

- signal-server-rs: 27 tests (6 new) — tenant filtering, push auth, offline queueing, newest-push-wins, delivery-and-ack, closed-connection fallback
- punchd-bridge-rs: 43 tests (17 new) — trust-anchor and identity refusals, type coercion, port ranges, no-op repeat pushes, TOML round-trip, token expiry
- TypeScript: 294 tests (34 new) — push delivery and the backends DSL

`tsc --noEmit` shows only the 6 errors that were already on main.

## Not verified

The `--features webview` code paths could not be compiled locally — the dev box lacks `libwebkit2gtk-4.1-dev`. The non-webview build compiles and all tests pass, and the gated code was checked by hand against the vendored `wry`/`tao` sources (which caught one missing import, fixed). **It needs a compile on CI or a machine with the GTK dev libs before shipping.**

The gateway binary also needs rebuilding and redeploying once before config push works against it.

## Note

Includes a one-line `Cargo.toml` change adding vendored openssl that was already in the working tree before this work — not mine, but carried along rather than left dangling.