### PR TITLE
Docs: signal server API, config push, and duplication trim

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -304,7 +304,9 @@ BRIDGE_URL=ws://localhost:8080 npm run dev
 
 ## TideCloak Notes
 
-- Client adapter config lives in `client/src/tidecloakAdapter.json`.
+- The adapter config lives server-side at `data/tidecloak.json` (or the
+  `TIDECLOAK_CONFIG` env var). The client fetches it at startup from
+  `GET /api/auth/config` — it isn't bundled into the frontend.
 - Admin capability is derived from TideCloak roles (app normalizes this into `user.role = "admin"` in the backend).
 
 ## Deployment

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -134,6 +134,11 @@ The gateway runs on your private network and connects outbound to the signal ser
 
 The gateway is `bridges/punchd-bridge-rs` (Rust).
 
+> The values below are the initial bootstrap. Once a gateway has registered,
+> editing it under **Punchd → Gateways** pushes changes down and it reloads
+> itself — see [SIGNAL-SERVER.md](SIGNAL-SERVER.md) section 5a for what is and
+> isn't pushable.
+
 ### Deploy (Docker)
 
 ```bash

--- a/docs/PUNCHD-GATEWAY.md
+++ b/docs/PUNCHD-GATEWAY.md
@@ -91,16 +91,16 @@ Two programs make up the punchd system. You may need one or both.
 the same network (local/offline mode). You only need the signal server for
 NAT traversal across the internet.
 
-### Ports at a glance
+### Gateway ports
 
-| Component | Port | Purpose |
-|-----------|------|---------|
-| Gateway | `7891` | Proxy (`/ws/ssh`, HTTP, RDP) — env `LISTEN_PORT` |
-| Gateway | `7892` | Health + logs — env `HEALTH_PORT` |
-| Gateway | `7893` | QUIC (P2P + VPN, UDP) — env `QUIC_PORT` |
-| Signal server | `9090` | Signaling WebSocket + HTTP relay — env `PORT` |
-| coturn (STUN/TURN) | `3478` UDP+TCP | Hole-punch + relay |
-| coturn relay range | `49152-65535` UDP | TURN media relay |
+| Port | Purpose | Env |
+|------|---------|-----|
+| `7891` | Proxy (`/ws/ssh`, HTTP, RDP) | `LISTEN_PORT` |
+| `7892` | Health + logs | `HEALTH_PORT` |
+| `7893` UDP | QUIC (P2P + VPN) | `QUIC_PORT` |
+
+Signal server and coturn ports are in
+[SIGNAL-SERVER.md](SIGNAL-SERVER.md) section 6.
 
 ---
 
@@ -264,6 +264,12 @@ key has a matching UPPER_CASE env var. Verified against
 `bridges/punchd-bridge-rs/src/config.rs`. Full table (RDP/VPN/TLS extras) is in
 [DEPLOYMENT.md](DEPLOYMENT.md) section 3.
 
+> **After the first install you rarely edit this file.** Saving under **Punchd →
+> Gateways** pushes the change to the running gateway, which rewrites its own
+> `gateway.toml` and reloads (rewritten from scratch, so comments don't survive).
+> Doesn't apply to offline gateways, or to the TideCloak and identity settings —
+> see [SIGNAL-SERVER.md](SIGNAL-SERVER.md) section 5a.
+
 | `gateway.toml` key | Env var | Default | Meaning |
 |--------------------|---------|---------|---------|
 | `gateway_id` | `GATEWAY_ID` | auto `gateway-<hex>` | Unique id for this gateway |
@@ -280,13 +286,9 @@ key has a matching UPPER_CASE env var. Verified against
 | `turn_server` | `TURN_SERVER` | — | TURN fallback, e.g. `turn:host:3478` |
 | `turn_secret` | `TURN_SECRET` | — | Must match the signal server's `TURN_SECRET` |
 
-**Backend string flags** (append to a backend URL):
-
-| Flag | Effect |
-|------|--------|
-| `;noauth` | Gateway skips JWT check for this backend (the backend does its own auth) |
-| `;stripauth` | Gateway validates the JWT but strips the `Authorization` header before proxying (HTTP) |
-| `;eddsa` | RDP only: passwordless auth via TideSSP |
+Backends take flags — `;noauth`, `;stripauth`, `;eddsa` — appended to the URL;
+[DEPLOYMENT.md](DEPLOYMENT.md) section 3 explains each. The console's gateway
+editor exposes them as checkboxes.
 
 KeyleSSH-server side, `BRIDGE_URL` (in `.env`) is unrelated to punchd — it's the
 fallback **external TCP bridge**, used only when a server has no `bridgeId` and

--- a/docs/SIGNAL-SERVER.md
+++ b/docs/SIGNAL-SERVER.md
@@ -76,10 +76,9 @@ curl https://YOUR_SIGNAL_SERVER:9090/health
 # {"status":"ok","gateways":1,"clients":0}   <- gateways went from 0 to 1
 ```
 
-> **Trust model:** the signal server is a "dumb relay" — it never authenticates
-> end users. All user auth (TideCloak JWT + DPoP, roles like `ssh:<user>`)
-> happens **at the gateway**. The signal server only gatekeeps gateway
-> registration with `API_SECRET`.
+> **Trust model:** the signal server never authenticates end users — it only
+> gatekeeps gateway registration and config pushes with `API_SECRET`. User auth
+> happens at the gateway; see [PUNCHD-GATEWAY.md](PUNCHD-GATEWAY.md) section 4.
 
 ---
 
@@ -202,6 +201,58 @@ Verified against `signal-server-rs/src/config.rs`.
 | `TLS_KEY_PATH` | unset | TLS private key |
 | `RELAY_HOST` | `punchd.keylessh.com` | Hostname advertised for the relay. The deploy script overrides this to your domain or `EXTERNAL_IP`. |
 | `TIDECLOAK_URL` | unset | TideCloak base URL |
+| `ALLOWED_ORIGINS` | `""` (empty = any) | Comma-separated origin allowlist for browser connections |
+| `TRUSTED_PROXIES` | `""` | Comma-separated proxy IPs whose forwarded-for header is believed when determining a client's real address. Leave empty unless the signal server sits behind a load balancer. |
+
+Two limits are compiled in rather than configurable: **20 connections per IP**
+and **100 messages per second** per connection.
+
+---
+
+## 5a. HTTP API
+
+Everything here is on the same port as the signaling WebSocket (`PORT`, default
+`9090`).
+
+| Endpoint | Auth | Purpose |
+|----------|------|---------|
+| `GET /health` | none | `{"status":"ok","gateways":N,"clients":N}` — the quickest check that a gateway registered |
+| `GET /webrtc-config` | none | ICE/TURN details and short-lived TURN credentials for browsers |
+| `GET /api/gateways` | none | Registered gateways, their backends, and the TideCloak issuer each one trusts |
+| `POST /api/gateways/{id}/config` | `x-api-secret` | Push config to a running gateway |
+
+### Filtering gateways by tenant
+
+When one signal server is shared by two KeyleSSH deployments (demo and devops,
+say), each console should see only its own gateways — the others could never
+connect anyway, since a gateway on another realm can't verify its tokens.
+Gateways advertise the issuer they trust, so:
+
+```bash
+curl "https://YOUR_SIGNAL_SERVER:9090/api/gateways?issuer=https://tc.example.com/realms/demo"
+```
+
+KeyleSSH passes its own issuer automatically. Gateways predating the field don't
+advertise one and are always returned, so a staggered upgrade won't blank a list.
+
+### Pushing config to a gateway
+
+`POST /api/gateways/{id}/config` forwards config down the gateway's existing
+WebSocket, so backends can be edited from the console instead of on the box.
+Authenticated with `API_SECRET` via an `x-api-secret` header.
+
+| Response | Meaning |
+|----------|---------|
+| `200`, `delivered: true` | Applied; `applied` and `rejected` list which fields |
+| `202`, `pending: true` | Gateway offline — held until it next registers (newest push wins) |
+| `401` | Wrong or missing `x-api-secret` |
+| `504` | Delivered, but no confirmation within 15s |
+
+The gateway refuses anything that would change which TideCloak it trusts
+(`tidecloak_config_*`, `auth_server_public_url`, `tc_internal_url`) or its own
+identity (`gateway_id`, `stun_server_url`, `api_secret`). Since `API_SECRET` is
+one shared value, a pushable trust anchor would let anyone holding it repoint a
+gateway at their own IdP.
 
 ---
 

--- a/docs/VPN-SETUP.md
+++ b/docs/VPN-SETUP.md
@@ -77,11 +77,9 @@ server** — the gateway *is* the VPN server.
 
 ### Ports
 
-| Where | Port | Purpose |
-|-------|------|---------|
-| Gateway | `7893` UDP | QUIC (P2P + VPN transport) — env/toml `QUIC_PORT`/`quic_port`, default 7893 |
-| Signal server | `9090` | Signaling (only for remote/NAT traversal) |
-| coturn | `3478` UDP+TCP + `49152-65535` UDP | STUN + TURN relay fallback |
+The VPN rides on the gateway's QUIC port, `7893/UDP` (`quic_port` /
+`QUIC_PORT`). Remote access additionally needs the signal server and coturn
+ports — see [SIGNAL-SERVER.md](SIGNAL-SERVER.md) section 6.
 
 ---
 
@@ -240,6 +238,7 @@ for the rest of the gateway config.
 | Remote client never connects (strict NAT) | P2P couldn't form. Ensure `--stun-server` points at a live signal server and TURN is configured (`--turn-server` + `--turn-secret` matching the signal server), with `3478` + `49152-65535/udp` open. |
 | Same-network client fails via signal server | Try direct mode: omit `--stun-server` and connect to a reachable gateway directly (offline mode, per DEPLOYMENT.md section 4). |
 | Login window never appears (desktop) | WebView2 (Windows) not available — reinstall the MSI; or use the CLI `--standalone` / `--token` path. |
+| Starts then quits without prompting, or won't reconnect and never asks for credentials | Build predating the stale-token fix: it reused the previous session's expired token and hid the login window. Upgrade; quitting from the tray was the old workaround. |
 
 ---
 


### PR DESCRIPTION
Follow-up to #48 — this commit was pushed just after that PR merged, so it missed the train.

## Made accurate

- **The signal server's HTTP API was undocumented** beyond `/health`. Adds a short section covering the endpoints, the `?issuer=` tenant filter, and the config push endpoint with its response codes and the fields a gateway refuses.
- `ALLOWED_ORIGINS` and `TRUSTED_PROXIES` were missing from the env reference, and the two compiled-in rate limits (20 connections/IP, 100 msg/sec) weren't mentioned anywhere.
- The gateway and deployment guides presented editing `gateway.toml` on the box as the only route. They now point at the console for anything pushable, noting the offline-gateway and trust-anchor exceptions.
- The VPN guide's "login window never appears" row blamed a missing WebView2 only — which would send someone reinstalling the MSI for the stale-token bug fixed in #48.
- `ARCHITECTURE.md` claimed the client adapter config is bundled at `client/src/tidecloakAdapter.json`. That file doesn't exist; the client fetches it from `GET /api/auth/config`, served from `data/tidecloak.json`.

## Made leaner

Net shorter despite the new API section:

- The full ports table appeared in four docs. `DEPLOYMENT.md` keeps the canonical one; each guide keeps only its own ports.
- The backend flags table had two copies; the gateway guide now names the flags in a line and defers to the reference.
- The trust model was explained in two places; `SIGNAL-SERVER.md` now states its narrow role and points at the full version.

## Checked

All internal doc links resolve. Every `path/to/file.ext` reference in the docs was checked against the tree — that's what surfaced the `tidecloakAdapter.json` error.

## Not covered

`flow-diagram.md` has ~30 `*Source:*` citations pointing at the deleted Node implementation, but it opens with a disclaimer calling them historical references — left alone rather than making a large change to a doc that's already honest about itself. Happy to re-point them at the Rust files or strip them if preferred.

`DEVELOPERS.md` and most of `DEPLOYMENT.md` were reviewed for cross-doc duplication and broken paths, not line-by-line against the code.