### PR TITLE
Unbreak Windows builds: scope vendored OpenSSL to Linux

### DIFF
--- a/bridges/punchd-bridge-rs/Cargo.toml
+++ b/bridges/punchd-bridge-rs/Cargo.toml
@@ -53,7 +53,6 @@ arc-swap = "1"
 ipnet = "2"
 wry = { version = "0.55", optional = true }
 tao = { version = "0.35", optional = true }
-openssl = { version = "0.10.81", features = ["vendored"] }
 
 [features]
 default = []
@@ -61,6 +60,11 @@ webview = ["wry", "tao"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tun = { version = "0.7", features = ["async"] }
+# Not used directly — forces native-tls to vendor OpenSSL so the Linux builds
+# are static and the .deb needs no system libssl. Linux only: native-tls uses
+# SChannel on Windows and Security.framework on macOS, so pulling openssl in
+# there only triggers a from-source build that fails under MinGW.
+openssl = { version = "0.10.81", features = ["vendored"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tun = { version = "0.7", features = ["async"] }


### PR DESCRIPTION
The Release workflow's three Windows jobs — `build-gateway-windows`, `build-endpoint-windows`, `build-vpn-msi` — all fail at the same point:

```
warning: openssl-sys@0.9.117: configuring OpenSSL build: 'perl' reported failure with exit code: 255
warning: openssl-sys@0.9.117: openssl-src: failed to build OpenSSL from source
error: failed to run custom build command for `openssl-sys v0.9.117`
```

This blocks the Windows gateway binary, so the remaining gateways can't be updated.

## Cause

`openssl = { version = "0.10.81", features = ["vendored"] }` was an unconditional dependency. Nothing in the crate uses `openssl::` — it's there to make `native-tls` vendor OpenSSL so Linux builds are static and the `.deb` needs no system libssl.

But unconditionally, it also forces a from-source OpenSSL build on Windows, where it is neither needed nor buildable under MinGW. `native-tls` uses **SChannel** on Windows:

```
$ cargo tree -i openssl-sys --target x86_64-pc-windows-gnu
openssl-sys v0.9.117
└── openssl v0.10.81
    └── punchd-bridge-rs          ← the explicit dependency, and nothing else

$ cargo tree -i schannel --target x86_64-pc-windows-gnu
schannel v0.1.29
├── native-tls v0.2.18            ← what actually provides TLS on Windows
```

## Fix

Move it under `[target.'cfg(target_os = "linux")'.dependencies]`, with a comment explaining why it exists at all.

## Verification

```
# Windows target — openssl-sys now absent entirely
$ cargo tree -i openssl-sys --target x86_64-pc-windows-gnu
warning: nothing to print.

# Linux target — vendored OpenSSL unchanged
$ cargo tree -i openssl-sys --target x86_64-unknown-linux-gnu
openssl-sys v0.9.117
├── native-tls v0.2.18 …
```

Linux builds clean and all 54 tests pass. The Windows compile itself needs CI to confirm — no MinGW here — but the dependency that was failing is no longer in the Windows tree.

## Note

This line arrived in #48; it was already in the working tree before that work and I carried it along rather than leaving it dangling, flagging it in that PR's description. It appears to have been added for the Linux static build without the Windows consequence being noticed.