### PR TITLE
Punchd: self-registering gateways and an installer that takes your config files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -441,11 +441,25 @@ jobs:
           New-Item -ItemType Directory -Force -Path target/release
           Copy-Item target/x86_64-pc-windows-gnu/release/punchd-bridge-rs.exe target/release/
 
+      - name: Compile installer custom actions (MSVC)
+        working-directory: bridges/punchd-bridge-rs/installer
+        shell: cmd
+        run: |
+          rem Locate Visual Studio via vswhere rather than a hardcoded path — the
+          rem runner image's VS edition and version change without notice.
+          set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+          if not exist "%VSWHERE%" (echo ERROR: vswhere.exe not found & exit /b 1)
+          for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSPATH=%%i"
+          if not defined VSPATH (echo ERROR: no Visual Studio install with the C++ toolset & exit /b 1)
+          call "%VSPATH%\Common7\Tools\VsDevCmd.bat" -arch=amd64 || exit /b 1
+          cl /LD /O2 GatewayCA.c GatewayCA.def /Fe:GatewayCA.dll /link msi.lib advapi32.lib shell32.lib user32.lib ole32.lib comdlg32.lib || exit /b 1
+
       - name: Build MSI
         run: |
           New-Item -ItemType Directory -Force -Path bridges/punchd-bridge-rs/out
           wix build bridges/punchd-bridge-rs/installer/GatewayProduct.wxs -arch x64 `
             -bindpath PunchdDir=bridges/punchd-bridge-rs/target/release `
+            -bindpath CaDir=bridges/punchd-bridge-rs/installer `
             -o bridges/punchd-bridge-rs/out/PunchdGateway.msi
 
       - uses: actions/upload-artifact@v4

--- a/bridges/punchd-bridge-rs/installer/GatewayCA.c
+++ b/bridges/punchd-bridge-rs/installer/GatewayCA.c
@@ -1,0 +1,241 @@
+/*
+ * WiX custom actions for the Punchd Gateway installer.
+ *
+ * Lets the installing admin pick gateway.toml and tidecloak.json during setup
+ * and copies them into ProgramData, instead of installing and then requiring a
+ * manual copy before the service can do anything useful.
+ *
+ * Both files are optional: an admin who has not generated them yet can install
+ * now and add them later, so a cancelled browse is never an install failure.
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <msi.h>
+#include <msiquery.h>
+#include <commdlg.h>
+#include <strsafe.h>
+#include <shlobj.h>
+
+#pragma comment(lib, "msi.lib")
+#pragma comment(lib, "shell32.lib")
+
+#define CONFIG_DIR      L"punchd-gateway"
+#define GATEWAY_TOML    L"gateway.toml"
+#define TIDECLOAK_JSON  L"tidecloak.json"
+
+/* Largest config we will accept. tidecloak.json carries a JWK set, so this is
+ * generous compared with the few KB either file normally occupies. */
+#define MAX_CONFIG_BYTES 262144
+
+typedef BOOL(WINAPI *PFN_GetOpenFileNameW)(LPOPENFILENAMEW);
+
+/* comdlg32 is loaded on demand: msiexec's UI sequence does not need it
+ * otherwise, and this keeps the DLL loadable where it is absent. */
+static BOOL DynGetOpenFileNameW(LPOPENFILENAMEW pOfn)
+{
+    HMODULE hMod = LoadLibraryW(L"comdlg32.dll");
+    if (!hMod) return FALSE;
+    PFN_GetOpenFileNameW pfn = (PFN_GetOpenFileNameW)GetProcAddress(hMod, "GetOpenFileNameW");
+    if (!pfn) { FreeLibrary(hMod); return FALSE; }
+    BOOL result = pfn(pOfn);
+    FreeLibrary(hMod);
+    return result;
+}
+
+static HWND InstallerWindow(void)
+{
+    HWND hwnd = FindWindowW(L"MsiDialogCloseClass", NULL);
+    if (!hwnd) hwnd = FindWindowW(L"MsiDialogNoCloseClass", NULL);
+    if (!hwnd) hwnd = GetForegroundWindow();
+    return hwnd;
+}
+
+/* Read a whole file into a NUL-terminated heap buffer. Caller frees. */
+static char *ReadWholeFile(const WCHAR *path, DWORD *outLen)
+{
+    HANDLE hFile = CreateFileW(path, GENERIC_READ, FILE_SHARE_READ,
+                               NULL, OPEN_EXISTING, 0, NULL);
+    if (hFile == INVALID_HANDLE_VALUE) return NULL;
+
+    DWORD fileSize = GetFileSize(hFile, NULL);
+    if (fileSize == 0 || fileSize > MAX_CONFIG_BYTES) {
+        CloseHandle(hFile);
+        return NULL;
+    }
+
+    char *content = (char *)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, fileSize + 1);
+    if (!content) { CloseHandle(hFile); return NULL; }
+
+    DWORD bytesRead = 0;
+    BOOL ok = ReadFile(hFile, content, fileSize, &bytesRead, NULL);
+    CloseHandle(hFile);
+    if (!ok) {
+        HeapFree(GetProcessHeap(), 0, content);
+        return NULL;
+    }
+    content[bytesRead] = '\0';
+    if (outLen) *outLen = bytesRead;
+    return content;
+}
+
+/*
+ * Shared browse-and-validate. `mustContainA`/`mustContainB` are substrings the
+ * file has to have to be plausibly the right file — enough to catch picking the
+ * wrong one of the two, without second-guessing a config the gateway itself
+ * will parse properly at startup.
+ */
+static UINT BrowseForConfig(MSIHANDLE hInstall,
+                            const WCHAR *filter,
+                            const WCHAR *defExt,
+                            const WCHAR *title,
+                            const WCHAR *property,
+                            const char *mustContainA,
+                            const char *mustContainB,
+                            const WCHAR *wrongFileMessage)
+{
+    WCHAR filePath[MAX_PATH] = {0};
+    HWND hwnd = InstallerWindow();
+
+    OPENFILENAMEW ofn;
+    ZeroMemory(&ofn, sizeof(ofn));
+    ofn.lStructSize = sizeof(OPENFILENAMEW);
+    ofn.hwndOwner = hwnd;
+    ofn.lpstrFilter = filter;
+    ofn.lpstrFile = filePath;
+    ofn.nMaxFile = MAX_PATH;
+    ofn.lpstrTitle = title;
+    ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
+    ofn.lpstrDefExt = defExt;
+
+    /* Cancelled: leave the property as it was. Selecting a file is optional, so
+     * this is a normal outcome and must not fail the install. */
+    if (!DynGetOpenFileNameW(&ofn))
+        return ERROR_SUCCESS;
+
+    DWORD len = 0;
+    char *content = ReadWholeFile(filePath, &len);
+    if (!content) {
+        MessageBoxW(hwnd, L"That file could not be read, or is empty or unusually large.",
+                    L"Punchd Gateway", MB_OK | MB_ICONERROR);
+        return ERROR_SUCCESS;
+    }
+
+    BOOL looksRight = (strstr(content, mustContainA) != NULL)
+                   && (mustContainB == NULL || strstr(content, mustContainB) != NULL);
+    HeapFree(GetProcessHeap(), 0, content);
+
+    if (!looksRight) {
+        MessageBoxW(hwnd, wrongFileMessage, L"Punchd Gateway", MB_OK | MB_ICONERROR);
+        return ERROR_SUCCESS;
+    }
+
+    MsiSetPropertyW(hInstall, property, filePath);
+    return ERROR_SUCCESS;
+}
+
+/* Immediate CA behind the "Browse..." button for gateway.toml. */
+UINT __stdcall BrowseGatewayToml(MSIHANDLE hInstall)
+{
+    return BrowseForConfig(
+        hInstall,
+        L"Gateway config (*.toml)\0*.toml\0All Files\0*.*\0",
+        L"toml",
+        L"Select gateway.toml",
+        L"GATEWAY_TOML_FILE",
+        "gateway_id",
+        NULL,
+        L"That does not look like a gateway.toml — it has no 'gateway_id'.\n\n"
+        L"Download it from KeyleSSH: Punchd \x2192 Gateways \x2192 Download gateway.toml");
+}
+
+/* Immediate CA behind the "Browse..." button for tidecloak.json. */
+UINT __stdcall BrowseTidecloakJson(MSIHANDLE hInstall)
+{
+    return BrowseForConfig(
+        hInstall,
+        L"TideCloak adapter config (*.json)\0*.json\0All Files\0*.*\0",
+        L"json",
+        L"Select tidecloak.json",
+        L"TIDECLOAK_JSON_FILE",
+        "realm",
+        "auth-server-url",
+        L"That does not look like a TideCloak adapter config — it needs 'realm' "
+        L"and 'auth-server-url'.\n\n"
+        L"Download it from KeyleSSH: Punchd \x2192 Gateways \x2192 Download tidecloak.json");
+}
+
+/* Copy one file into the config directory, creating the directory if needed. */
+static BOOL CopyIntoConfigDir(const WCHAR *source, const WCHAR *destName)
+{
+    if (!source || !*source) return TRUE; /* nothing chosen — fine */
+
+    WCHAR destDir[MAX_PATH];
+    if (FAILED(SHGetFolderPathW(NULL, CSIDL_COMMON_APPDATA, NULL, 0, destDir)))
+        return FALSE;
+
+    if (FAILED(StringCchCatW(destDir, MAX_PATH, L"\\" CONFIG_DIR)))
+        return FALSE;
+    CreateDirectoryW(destDir, NULL);
+
+    WCHAR destPath[MAX_PATH];
+    if (FAILED(StringCchCopyW(destPath, MAX_PATH, destDir))) return FALSE;
+    if (FAILED(StringCchCatW(destPath, MAX_PATH, L"\\"))) return FALSE;
+    if (FAILED(StringCchCatW(destPath, MAX_PATH, destName))) return FALSE;
+
+    /* Overwrite: choosing a file in the wizard is an explicit instruction to
+     * use it, including over a config left by an earlier install. */
+    return CopyFileW(source, destPath, FALSE);
+}
+
+/*
+ * Deferred CA. CustomActionData carries both paths as "<toml>|<json>", either
+ * side possibly empty.
+ */
+UINT __stdcall CopyGatewayConfig(MSIHANDLE hInstall)
+{
+    WCHAR data[MAX_PATH * 2 + 2];
+    DWORD dataLen = sizeof(data) / sizeof(WCHAR);
+
+    if (MsiGetPropertyW(hInstall, L"CustomActionData", data, &dataLen) != ERROR_SUCCESS
+        || dataLen == 0)
+        return ERROR_SUCCESS; /* nothing chosen — install proceeds unconfigured */
+
+    WCHAR *sep = wcschr(data, L'|');
+    const WCHAR *tomlPath = data;
+    const WCHAR *jsonPath = L"";
+    if (sep) {
+        *sep = L'\0';
+        jsonPath = sep + 1;
+    }
+
+    if (!CopyIntoConfigDir(tomlPath, GATEWAY_TOML)) return ERROR_INSTALL_FAILURE;
+    if (!CopyIntoConfigDir(jsonPath, TIDECLOAK_JSON)) return ERROR_INSTALL_FAILURE;
+
+    return ERROR_SUCCESS;
+}
+
+/*
+ * Deferred CA on uninstall. Removes only the files this installer places, so an
+ * admin's other files in the directory survive.
+ */
+UINT __stdcall RemoveGatewayConfig(MSIHANDLE hInstall)
+{
+    (void)hInstall;
+    WCHAR base[MAX_PATH];
+    if (FAILED(SHGetFolderPathW(NULL, CSIDL_COMMON_APPDATA, NULL, 0, base)))
+        return ERROR_SUCCESS;
+    if (FAILED(StringCchCatW(base, MAX_PATH, L"\\" CONFIG_DIR L"\\")))
+        return ERROR_SUCCESS;
+
+    WCHAR path[MAX_PATH];
+    if (SUCCEEDED(StringCchCopyW(path, MAX_PATH, base))
+        && SUCCEEDED(StringCchCatW(path, MAX_PATH, GATEWAY_TOML)))
+        DeleteFileW(path);
+
+    if (SUCCEEDED(StringCchCopyW(path, MAX_PATH, base))
+        && SUCCEEDED(StringCchCatW(path, MAX_PATH, TIDECLOAK_JSON)))
+        DeleteFileW(path);
+
+    return ERROR_SUCCESS;
+}

--- a/bridges/punchd-bridge-rs/installer/GatewayCA.def
+++ b/bridges/punchd-bridge-rs/installer/GatewayCA.def
@@ -1,0 +1,6 @@
+LIBRARY GatewayCA
+EXPORTS
+    BrowseGatewayToml
+    BrowseTidecloakJson
+    CopyGatewayConfig
+    RemoveGatewayConfig

--- a/bridges/punchd-bridge-rs/installer/GatewayProduct.wxs
+++ b/bridges/punchd-bridge-rs/installer/GatewayProduct.wxs
@@ -17,6 +17,15 @@
 
     <Property Id="REINSTALLMODE" Value="amus" Secure="yes" />
 
+    <!-- Config files chosen in the wizard. Both optional: an admin without them
+         yet can install now and drop them in later. Settable on the command line
+         for unattended installs:
+           msiexec /i PunchdGateway.msi /qn ^
+             GATEWAY_TOML_FILE="C:\path\gateway.toml" ^
+             TIDECLOAK_JSON_FILE="C:\path\tidecloak.json" -->
+    <Property Id="GATEWAY_TOML_FILE" Secure="yes" />
+    <Property Id="TIDECLOAK_JSON_FILE" Secure="yes" />
+
     <!-- ═══════════ Directory layout ═══════════ -->
 
     <!-- Punchd Gateway → Program Files\PunchdGateway -->
@@ -67,17 +76,94 @@
       <ComponentRef Id="GatewayConfigDirectory" />
     </Feature>
 
+    <!-- ═══════════ Custom actions: pick and place the config files ═══════════ -->
+
+    <Binary Id="GatewayCA" SourceFile="!(bindpath.CaDir)\GatewayCA.dll" />
+
+    <CustomAction Id="BrowseGatewayToml" BinaryRef="GatewayCA"
+                  DllEntry="BrowseGatewayToml" Execute="immediate" Return="ignore" />
+    <CustomAction Id="BrowseTidecloakJson" BinaryRef="GatewayCA"
+                  DllEntry="BrowseTidecloakJson" Execute="immediate" Return="ignore" />
+
+    <!-- Deferred actions run without access to properties, so both paths are
+         handed over through CustomActionData as "<toml>|<json>". -->
+    <CustomAction Id="SetCopyGatewayConfigData" Property="CopyGatewayConfig"
+                  Value="[GATEWAY_TOML_FILE]|[TIDECLOAK_JSON_FILE]" Execute="immediate" />
+    <CustomAction Id="CopyGatewayConfig" BinaryRef="GatewayCA"
+                  DllEntry="CopyGatewayConfig" Execute="deferred"
+                  Impersonate="no" Return="check" />
+    <CustomAction Id="RemoveGatewayConfig" BinaryRef="GatewayCA"
+                  DllEntry="RemoveGatewayConfig" Execute="deferred"
+                  Impersonate="no" Return="ignore" />
+
+    <InstallExecuteSequence>
+      <!-- Place config before the service starts, so the gateway's first start
+           already sees its configuration. InstallServices runs inside
+           InstallFinalize, so scheduling before that is sufficient. -->
+      <Custom Action="SetCopyGatewayConfigData" Before="CopyGatewayConfig"
+              Condition="NOT REMOVE" />
+      <Custom Action="CopyGatewayConfig" Before="InstallFinalize"
+              Condition="NOT REMOVE" />
+      <Custom Action="RemoveGatewayConfig" After="InstallInitialize"
+              Condition="REMOVE~=&quot;ALL&quot;" />
+      <ScheduleReboot After="InstallFinalize" Condition="0" />
+    </InstallExecuteSequence>
+
     <!-- ═══════════ Installer UI ═══════════ -->
     <UI>
       <TextStyle Id="TitleFont" FaceName="Tahoma" Size="10" Bold="yes" />
       <TextStyle Id="BodyFont" FaceName="Tahoma" Size="8" />
+      <TextStyle Id="PathFont" FaceName="Tahoma" Size="8" />
 
       <Dialog Id="WelcomeDlg" Width="370" Height="270" Title="Punchd Gateway Setup">
         <Control Id="Title" Type="Text" X="20" Y="20" Width="330" Height="20"
                  Text="{\TitleFont}Welcome to Punchd Gateway Setup" />
-        <Control Id="Desc" Type="Text" X="20" Y="50" Width="330" Height="60"
-                 Text="{\BodyFont}This will install the Punchd Gateway as a Windows service. The gateway provides NAT-traversing reverse proxy with QUIC VPN, WebRTC, and TideCloak OIDC authentication. Place your gateway.toml and tidecloak.json in ProgramData\punchd-gateway after installation." />
+        <Control Id="Desc" Type="Text" X="20" Y="50" Width="330" Height="70"
+                 Text="{\BodyFont}This installs the Punchd Gateway as a Windows service — a NAT-traversing reverse proxy with QUIC VPN, WebRTC and TideCloak authentication.&#10;&#10;Next you can select your configuration files, or skip and add them later." />
         <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17"
+                 Default="yes" Text="Next">
+          <Publish Event="NewDialog" Value="ConfigDlg" />
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17"
+                 Cancel="yes" Text="Cancel">
+          <Publish Event="SpawnDialog" Value="CancelDlg" />
+        </Control>
+      </Dialog>
+
+      <Dialog Id="ConfigDlg" Width="370" Height="270" Title="Punchd Gateway Setup">
+        <Control Id="Title" Type="Text" X="20" Y="15" Width="330" Height="20"
+                 Text="{\TitleFont}Configuration files" />
+        <Control Id="Desc" Type="Text" X="20" Y="38" Width="330" Height="34"
+                 Text="{\BodyFont}Both are optional. Leave them blank to install now and copy them into C:\ProgramData\punchd-gateway later." />
+
+        <!-- gateway.toml -->
+        <Control Id="TomlLabel" Type="Text" X="20" Y="82" Width="330" Height="10"
+                 Text="{\BodyFont}gateway.toml — gateway ID, signal server and backends" />
+        <Control Id="TomlPath" Type="Text" X="20" Y="96" Width="245" Height="14"
+                 Property="GATEWAY_TOML_FILE" Text="{\PathFont}[GATEWAY_TOML_FILE]" />
+        <Control Id="TomlBrowse" Type="PushButton" X="272" Y="94" Width="78" Height="17"
+                 Text="Browse...">
+          <Publish Event="DoAction" Value="BrowseGatewayToml" />
+        </Control>
+
+        <!-- tidecloak.json -->
+        <Control Id="JsonLabel" Type="Text" X="20" Y="126" Width="330" Height="10"
+                 Text="{\BodyFont}tidecloak.json — the TideCloak adapter config used to verify logins" />
+        <Control Id="JsonPath" Type="Text" X="20" Y="140" Width="245" Height="14"
+                 Property="TIDECLOAK_JSON_FILE" Text="{\PathFont}[TIDECLOAK_JSON_FILE]" />
+        <Control Id="JsonBrowse" Type="PushButton" X="272" Y="138" Width="78" Height="17"
+                 Text="Browse...">
+          <Publish Event="DoAction" Value="BrowseTidecloakJson" />
+        </Control>
+
+        <Control Id="Hint" Type="Text" X="20" Y="172" Width="330" Height="30"
+                 Text="{\BodyFont}Both files are downloadable from KeyleSSH under Punchd &#8594; Gateways. Selecting a file replaces any copy already present." />
+
+        <Control Id="Back" Type="PushButton" X="168" Y="243" Width="56" Height="17"
+                 Text="Back">
+          <Publish Event="NewDialog" Value="WelcomeDlg" />
+        </Control>
+        <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17"
                  Default="yes" Text="Install">
           <Publish Event="EndDialog" Value="Return" />
         </Control>
@@ -103,8 +189,8 @@
       <Dialog Id="ExitDlg" Width="370" Height="270" Title="Punchd Gateway Setup Complete">
         <Control Id="Title" Type="Text" X="20" Y="20" Width="330" Height="20"
                  Text="{\TitleFont}Installation Complete" />
-        <Control Id="Desc" Type="Text" X="20" Y="50" Width="330" Height="70"
-                 Text="{\BodyFont}Punchd Gateway has been installed as a Windows service. Copy your gateway.toml and tidecloak.json to C:\ProgramData\punchd-gateway\ then restart the service." />
+        <Control Id="Desc" Type="Text" X="20" Y="50" Width="330" Height="80"
+                 Text="{\BodyFont}Punchd Gateway is installed and running as a Windows service.&#10;&#10;Any configuration files you selected are in C:\ProgramData\punchd-gateway. To change them later, edit that folder and restart the PunchdGateway service — or manage the gateway from the KeyleSSH console." />
         <Control Id="Finish" Type="PushButton" X="304" Y="243" Width="56" Height="17"
                  Default="yes" Cancel="yes" Text="Finish">
           <Publish Event="EndDialog" Value="Return" />
@@ -116,10 +202,6 @@
         <Show Dialog="ExitDlg" After="ExecuteAction" />
       </InstallUISequence>
     </UI>
-
-    <InstallExecuteSequence>
-      <ScheduleReboot After="InstallFinalize" Condition="0" />
-    </InstallExecuteSequence>
 
   </Package>
 </Wix>

--- a/bridges/punchd-bridge-rs/src/config.rs
+++ b/bridges/punchd-bridge-rs/src/config.rs
@@ -294,6 +294,64 @@ pub fn config_file_path() -> PathBuf {
     dir.join("gateway.toml")
 }
 
+// ── Self-reported config ────────────────────────────────────────
+
+/// Render backends back to the `Name=url;flags` form used in gateway.toml.
+pub fn backends_to_string(backends: &[BackendEntry]) -> String {
+    backends
+        .iter()
+        .map(|b| {
+            let mut entry = format!("{}={}", b.name, b.url);
+            if b.no_auth {
+                entry.push_str(";noauth");
+            }
+            if b.strip_auth {
+                entry.push_str(";stripauth");
+            }
+            if b.auth == BackendAuth::EdDSA {
+                entry.push_str(";eddsa");
+            }
+            entry
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// The gateway's current settings, advertised at registration so a console can
+/// show a self-registered gateway accurately and seed a config record from it.
+///
+/// Deliberately limited to the fields a console is allowed to push back, so what
+/// an admin sees is exactly what they can edit. Secrets — `api_secret`,
+/// `turn_secret` — and the TideCloak config are never reported: they are not
+/// pushable, and the signal server relaying this has no business holding them.
+pub fn reported_config(config: &ServerConfig) -> serde_json::Value {
+    let mut reported = serde_json::json!({
+        "backends": backends_to_string(&config.backends),
+        "listen_port": config.listen_port,
+        "health_port": config.health_port,
+        "quic_port": config.quic_port,
+        "https": config.https,
+        "tls_hostname": config.tls_hostname,
+    });
+
+    if let Some(ref name) = config.display_name {
+        reported["display_name"] = serde_json::json!(name);
+    }
+    if let Some(ref desc) = config.description {
+        reported["description"] = serde_json::json!(desc);
+    }
+    if let Some(ref url) = config.server_url {
+        reported["server_url"] = serde_json::json!(url);
+    }
+    if !config.ice_servers.is_empty() {
+        reported["ice_servers"] = serde_json::json!(config.ice_servers.join(","));
+    }
+    if let Some(ref turn) = config.turn_server {
+        reported["turn_server"] = serde_json::json!(turn);
+    }
+    reported
+}
+
 // ── Remote config push ──────────────────────────────────────────
 
 /// Fields that may never be set from a remote push.
@@ -960,6 +1018,92 @@ mod remote_config_tests {
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).expect("scratch dir");
         dir
+    }
+
+    fn server_config() -> ServerConfig {
+        ServerConfig {
+            listen_port: 7891,
+            health_port: 7892,
+            backend_url: String::new(),
+            backends: parse_backends_str("App=http://10.0.0.5:8080, Desk=rdp://10.0.0.9:3389;eddsa"),
+            stun_server_url: "wss://signal.example.com".into(),
+            gateway_id: "gw-1".into(),
+            strip_auth_header: false,
+            auth_server_public_url: Some("https://tc.example.com".into()),
+            ice_servers: vec!["stun:1.2.3.4:3478".into()],
+            turn_server: Some("turn:1.2.3.4:3478".into()),
+            turn_secret: "turn-secret".into(),
+            api_secret: "shared-secret".into(),
+            display_name: Some("Demo Gateway".into()),
+            description: None,
+            https: true,
+            tls_hostname: "gw.example.com".into(),
+            tc_internal_url: None,
+            server_url: Some("https://console.example.com".into()),
+            quic_port: 7893,
+        }
+    }
+
+    #[test]
+    fn backends_round_trip_through_the_string_form() {
+        let original = "App=http://10.0.0.5:8080, Desk=rdp://10.0.0.9:3389;eddsa, Shell=ssh://h:22;noauth";
+        assert_eq!(backends_to_string(&parse_backends_str(original)), original);
+    }
+
+    #[test]
+    fn reports_the_editable_settings() {
+        let reported = reported_config(&server_config());
+
+        assert_eq!(reported["backends"].as_str(), Some("App=http://10.0.0.5:8080, Desk=rdp://10.0.0.9:3389;eddsa"));
+        assert_eq!(reported["listen_port"].as_u64(), Some(7891));
+        assert_eq!(reported["health_port"].as_u64(), Some(7892));
+        assert_eq!(reported["quic_port"].as_u64(), Some(7893));
+        assert_eq!(reported["https"].as_bool(), Some(true));
+        assert_eq!(reported["tls_hostname"].as_str(), Some("gw.example.com"));
+        assert_eq!(reported["display_name"].as_str(), Some("Demo Gateway"));
+        assert_eq!(reported["server_url"].as_str(), Some("https://console.example.com"));
+        assert_eq!(reported["ice_servers"].as_str(), Some("stun:1.2.3.4:3478"));
+        assert_eq!(reported["turn_server"].as_str(), Some("turn:1.2.3.4:3478"));
+    }
+
+    #[test]
+    fn never_reports_secrets_or_the_trust_anchor() {
+        let reported = reported_config(&server_config());
+        let serialized = reported.to_string();
+
+        for secret in ["shared-secret", "turn-secret"] {
+            assert!(!serialized.contains(secret), "reported config leaked {secret}: {serialized}");
+        }
+        for field in ["api_secret", "turn_secret", "tidecloak_config_b64", "auth_server_public_url", "tc_internal_url"] {
+            assert!(reported.get(field).is_none(), "reported config must not include {field}");
+        }
+    }
+
+    #[test]
+    fn every_reported_field_is_one_the_console_may_push_back() {
+        // What an admin sees must be exactly what they can edit, or the console
+        // would show settings that silently ignore any change.
+        let reported = reported_config(&server_config());
+        for field in reported.as_object().unwrap().keys() {
+            assert!(
+                !PROTECTED_FIELDS.contains(&field.as_str()),
+                "{field} is reported but refused on push"
+            );
+        }
+    }
+
+    #[test]
+    fn omits_settings_that_are_not_configured() {
+        let mut config = server_config();
+        config.turn_server = None;
+        config.server_url = None;
+        config.ice_servers.clear();
+        config.display_name = None;
+
+        let reported = reported_config(&config);
+        for field in ["turn_server", "server_url", "ice_servers", "display_name", "description"] {
+            assert!(reported.get(field).is_none(), "{field} should be omitted when unset");
+        }
     }
 
     #[test]

--- a/bridges/punchd-bridge-rs/src/main.rs
+++ b/bridges/punchd-bridge-rs/src/main.rs
@@ -170,6 +170,9 @@ async fn run_gateway() {
             // affects HTTP relay routing. Lets consoles filter to their own tenant.
             meta["issuer"] = serde_json::json!(tc_config.issuer());
             meta["clientId"] = serde_json::json!(tc_config.resource);
+            // Current settings, so a console can list a self-registered gateway
+            // accurately and seed a config record without guessing.
+            meta["config"] = config::reported_config(&config);
             if let Ok(public_url) = std::env::var("PUBLIC_URL") {
                 meta["publicUrl"] = serde_json::json!(public_url);
             }
@@ -223,6 +226,7 @@ async fn run_gateway() {
             }
             meta["issuer"] = serde_json::json!(new_tc_config.issuer());
             meta["clientId"] = serde_json::json!(new_tc_config.resource);
+            meta["config"] = config::reported_config(&new_config);
             stun_reg.update_metadata(meta);
         });
     }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -545,7 +545,8 @@ export const api = {
         }),
     },
     gatewayConfigs: {
-      list: () => apiRequest<GatewayConfigSummary[]>("/api/admin/gateway-configs"),
+      // Includes self-registered gateways that have no record yet.
+      list: () => apiRequest<ListedGateway[]>("/api/admin/gateway-configs"),
       get: (id: string) => apiRequest<GatewayConfigSummary>(`/api/admin/gateway-configs/${id}`),
       create: (data: any) => apiRequest<GatewayConfigSummary>("/api/admin/gateway-configs", { method: "POST", body: JSON.stringify(data) }),
       // Saving also pushes to the running gateway; `push` reports how that went.
@@ -568,6 +569,33 @@ export interface GatewayPushResult {
   changed: boolean;
   error?: string | null;
   message?: string;
+}
+
+// A gateway that self-registered but has no config record yet. It becomes a
+// normal GatewayConfigSummary the first time it is edited (adopted).
+export interface DiscoveredGateway {
+  id: string;
+  gatewayId: string;
+  displayName: string | null;
+  discovered: true;
+  online: boolean;
+  signalServerName: string | null;
+  stunServerUrl: string | null;
+  issuer: string | null;
+  backends: string | null;
+  listenPort: number | null;
+  healthPort: number | null;
+  https: boolean | null;
+  tlsHostname: string | null;
+  serverUrl: string | null;
+  iceServers: string | null;
+  turnServer: string | null;
+}
+
+export type ListedGateway = GatewayConfigSummary | DiscoveredGateway;
+
+export function isDiscovered(g: ListedGateway): g is DiscoveredGateway {
+  return (g as DiscoveredGateway).discovered === true;
 }
 
 // Gateway config (managed from admin UI)

--- a/client/src/pages/AdminGateways.tsx
+++ b/client/src/pages/AdminGateways.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
 import { queryClient } from "@/lib/queryClient";
-import { api, type GatewayConfigSummary, type GatewayPushResult } from "@/lib/api";
+import { api, isDiscovered, type GatewayConfigSummary, type GatewayPushResult, type ListedGateway } from "@/lib/api";
 import {
   parseBackends,
   serializeBackends,
@@ -33,7 +33,7 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Router, Plus, Pencil, Trash2, Download, Wifi, Copy, Check, KeyRound, FileDown, Shield, Settings, UploadCloud, Loader2 } from "lucide-react";
+import { Router, Plus, Pencil, Trash2, Download, Wifi, Copy, Check, KeyRound, FileDown, Shield, Settings, UploadCloud, Loader2, Radar } from "lucide-react";
 import type { SignalServer } from "@shared/schema";
 import { useAuth, useAuthConfig } from "@/contexts/AuthContext";
 import { useMemo } from "react";
@@ -219,7 +219,7 @@ const defaultForm: Partial<GatewayConfigSummary> = {
 export default function AdminGateways() {
   const { toast } = useToast();
   const authConfig = useAuthConfig();
-  const [editing, setEditing] = useState<GatewayConfigSummary | null>(null);
+  const [editing, setEditing] = useState<ListedGateway | null>(null);
   const [creating, setCreating] = useState(false);
   const [deleting, setDeleting] = useState<GatewayConfigSummary | null>(null);
   const [form, setForm] = useState<Partial<GatewayConfigSummary>>(defaultForm);
@@ -290,8 +290,8 @@ export default function AdminGateways() {
     setCreating(true);
   };
 
-  const handleEdit = (config: GatewayConfigSummary) => {
-    setForm({ ...config });
+  const handleEdit = (config: ListedGateway) => {
+    setForm({ ...(config as Partial<GatewayConfigSummary>) });
     setEditing(config);
   };
 
@@ -482,10 +482,21 @@ export default function AdminGateways() {
                 </TableHeader>
                 <TableBody>
                   {(configs || []).map((config) => (
-                    <TableRow key={config.id}>
+                    <TableRow key={config.id} className={isDiscovered(config) ? "bg-muted/30" : undefined}>
                       <TableCell>
                         <div>
-                          <p className="font-medium">{config.displayName || config.gatewayId}</p>
+                          <p className="font-medium flex items-center gap-2">
+                            {config.displayName || config.gatewayId}
+                            {isDiscovered(config) && (
+                              <Badge
+                                variant="outline"
+                                className="gap-1 text-[10px] font-normal"
+                                title="This gateway registered itself. Edit it to start managing its config from here."
+                              >
+                                <Radar className="h-3 w-3" /> Self-registered
+                              </Badge>
+                            )}
+                          </p>
                           <p className="text-xs text-muted-foreground font-mono flex items-center gap-1">
                             {config.gatewayId}
                             <button onClick={() => handleCopyId(config.gatewayId)} className="hover:text-foreground">
@@ -501,7 +512,11 @@ export default function AdminGateways() {
                         <p className="text-xs text-muted-foreground truncate max-w-[200px]">{config.backends || "—"}</p>
                       </TableCell>
                       <TableCell>
-                        {config.vpnEnabled ? (
+                        {isDiscovered(config) ? (
+                          <Badge variant="outline" className="text-muted-foreground">
+                            {config.online ? "Online" : "Offline"}
+                          </Badge>
+                        ) : config.vpnEnabled ? (
                           <Badge variant="outline" className="gap-1 bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/30 dark:text-blue-400">
                             <Wifi className="h-3 w-3" /> On
                           </Badge>
@@ -511,6 +526,12 @@ export default function AdminGateways() {
                       </TableCell>
                       <TableCell className="text-right">
                         <div className="flex items-center justify-end gap-1">
+                          {isDiscovered(config) ? (
+                            <Button size="sm" variant="outline" className="gap-1.5" onClick={() => handleEdit(config)}>
+                              <Pencil className="h-3.5 w-3.5" /> Manage
+                            </Button>
+                          ) : (
+                          <>
                           <Button
                             size="icon"
                             variant="ghost"
@@ -536,6 +557,8 @@ export default function AdminGateways() {
                           <Button size="icon" variant="ghost" onClick={() => setDeleting(config)}>
                             <Trash2 className="h-4 w-4" />
                           </Button>
+                          </>
+                          )}
                         </div>
                       </TableCell>
                     </TableRow>
@@ -554,7 +577,10 @@ export default function AdminGateways() {
         </TabsContent>
 
         <TabsContent value="configs">
-          {(!configs || configs.length === 0) ? (
+          {(() => {
+          // Only adopted gateways have a stored record to generate files from.
+          const managed = (configs || []).filter((c) => !isDiscovered(c)) as GatewayConfigSummary[];
+          return (!managed || managed.length === 0) ? (
             <Card>
               <CardContent className="py-8 text-center text-muted-foreground">
                 No gateway configs. Create a gateway first to download configuration files.
@@ -562,7 +588,7 @@ export default function AdminGateways() {
             </Card>
           ) : (
             <div className="space-y-4">
-              {(configs || []).map((config) => (
+              {managed.map((config) => (
                 <Card key={config.id}>
                   <CardContent className="p-4 sm:p-6">
                     <div className="flex items-center gap-3 mb-4">
@@ -639,7 +665,8 @@ export default function AdminGateways() {
                 </Card>
               ))}
             </div>
-          )}
+          );
+          })()}
         </TabsContent>
       </Tabs>
 

--- a/server/lib/gatewayDiscovery.ts
+++ b/server/lib/gatewayDiscovery.ts
@@ -1,0 +1,164 @@
+import type { GatewayConfig } from "../storage";
+import type { SignalServer } from "@shared/schema";
+
+/**
+ * Self-registered gateways.
+ *
+ * A gateway that registers with a signal server is live and usable, but until
+ * someone creates a matching config record it cannot be managed from the
+ * console. Rather than making an admin retype what the gateway already knows,
+ * the console lists live gateways alongside stored ones and adopts a gateway —
+ * creating its record — the first time anyone edits it.
+ *
+ * The gateway reports its own settings at registration, so an adopted record
+ * starts out matching reality. Without that, adoption would seed blanks and the
+ * first save would push them over a working config.
+ */
+
+/** A gateway as the signal server reports it. */
+export interface LiveGateway {
+  id: string;
+  displayName?: string | null;
+  description?: string | null;
+  online?: boolean;
+  issuer?: string | null;
+  /** Settings the gateway reports about itself, in gateway.toml key names. */
+  config?: Record<string, unknown> | null;
+  signalServerId?: string;
+  signalServerName?: string;
+  signalServerUrl?: string;
+}
+
+/** A stored config, or a live gateway that has no record yet. */
+export type ListedGateway = (GatewayConfig & { discovered?: false }) | DiscoveredGateway;
+
+export interface DiscoveredGateway {
+  /** Synthetic id — no database row exists yet. */
+  id: string;
+  gatewayId: string;
+  displayName: string | null;
+  discovered: true;
+  online: boolean;
+  signalServerName: string | null;
+  stunServerUrl: string | null;
+  issuer: string | null;
+  /** Editable settings as the gateway reports them. */
+  backends: string | null;
+  listenPort: number | null;
+  healthPort: number | null;
+  https: boolean | null;
+  tlsHostname: string | null;
+  serverUrl: string | null;
+  iceServers: string | null;
+  turnServer: string | null;
+}
+
+/** Prefix marking an id as not-yet-adopted, so the UI and API can tell. */
+export const DISCOVERED_PREFIX = "discovered:";
+
+export function isDiscoveredId(id: string): boolean {
+  return id.startsWith(DISCOVERED_PREFIX);
+}
+
+export function gatewayIdFromDiscoveredId(id: string): string {
+  return id.slice(DISCOVERED_PREFIX.length);
+}
+
+function str(value: unknown): string | null {
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+function port(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 65535
+    ? value
+    : null;
+}
+
+function bool(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+/** Convert a live gateway into a listable entry using what it reported. */
+export function toDiscovered(live: LiveGateway): DiscoveredGateway {
+  const c = live.config ?? {};
+  return {
+    id: `${DISCOVERED_PREFIX}${live.id}`,
+    gatewayId: live.id,
+    displayName: str(c.display_name) ?? str(live.displayName),
+    discovered: true,
+    online: live.online !== false,
+    signalServerName: live.signalServerName ?? null,
+    stunServerUrl: live.signalServerUrl ?? null,
+    issuer: live.issuer ?? null,
+    backends: str(c.backends),
+    listenPort: port(c.listen_port),
+    healthPort: port(c.health_port),
+    https: bool(c.https),
+    tlsHostname: str(c.tls_hostname),
+    serverUrl: str(c.server_url),
+    iceServers: str(c.ice_servers),
+    turnServer: str(c.turn_server),
+  };
+}
+
+/**
+ * List stored configs plus any live gateway without one.
+ *
+ * Matching is on `gatewayId`, case-insensitively — that is the identity the
+ * gateway registers under and the key config pushes are addressed to.
+ */
+export function mergeDiscovered(
+  stored: GatewayConfig[],
+  live: LiveGateway[]
+): ListedGateway[] {
+  const known = new Set(stored.map((c) => c.gatewayId.toLowerCase()));
+  const seen = new Set<string>();
+  const discovered: DiscoveredGateway[] = [];
+
+  for (const gw of live) {
+    const key = gw.id.toLowerCase();
+    // A gateway can be registered with more than one signal server; list it once.
+    if (known.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    discovered.push(toDiscovered(gw));
+  }
+
+  return [...stored, ...discovered];
+}
+
+/**
+ * Build the record to create when a discovered gateway is adopted.
+ *
+ * Only fields the gateway actually reported are set. Anything it did not report
+ * is left to the storage layer's defaults rather than guessed, so adoption never
+ * invents a value that a later push would write back to the gateway.
+ */
+export function adoptionRecord(live: LiveGateway): Record<string, unknown> {
+  const d = toDiscovered(live);
+  const record: Record<string, unknown> = { gatewayId: d.gatewayId };
+
+  const optional: Record<string, unknown> = {
+    displayName: d.displayName,
+    stunServerUrl: d.stunServerUrl,
+    backends: d.backends,
+    listenPort: d.listenPort,
+    healthPort: d.healthPort,
+    https: d.https,
+    tlsHostname: d.tlsHostname,
+    serverUrl: d.serverUrl,
+    iceServers: d.iceServers,
+    turnServer: d.turnServer,
+  };
+  for (const [key, value] of Object.entries(optional)) {
+    if (value !== null && value !== undefined) record[key] = value;
+  }
+  return record;
+}
+
+/** Find the signal server a live gateway registered with. */
+export function signalServerFor(
+  live: LiveGateway,
+  signalServers: SignalServer[]
+): SignalServer | undefined {
+  return signalServers.find((ss) => ss.id === live.signalServerId || ss.url === live.signalServerUrl);
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,6 +1,6 @@
 import express, { type Express } from "express";
 import type { Server } from "http";
-import { storage, approvalStorage, policyStorage, pendingPolicyStorage, templateStorage, subscriptionStorage, recordingStorage, fileOperationStorage, bridgeStorage, signalServerStorage, gatewayConfigStorage, type ApprovalType } from "./storage";
+import { storage, approvalStorage, policyStorage, pendingPolicyStorage, templateStorage, subscriptionStorage, recordingStorage, fileOperationStorage, bridgeStorage, signalServerStorage, gatewayConfigStorage, type ApprovalType, type GatewayConfig } from "./storage";
 import { subscriptionTiers, type SubscriptionTier } from "@shared/schema";
 import * as stripeLib from "./lib/stripe";
 import { log, logForseti, logError } from "./logger";
@@ -140,6 +140,13 @@ import { getAllowedSshUsersFromToken } from "./lib/auth/sshUsers";
 import { parseDestRolesFromToken, hasDestAccess } from "./lib/auth/destRoles";
 import { verifyTideCloakToken } from "./lib/auth/tideJWT";
 import { pushGatewayConfig, matchSignalServer } from "./lib/gatewayPush";
+import {
+  mergeDiscovered,
+  adoptionRecord,
+  isDiscoveredId,
+  gatewayIdFromDiscoveredId,
+  type LiveGateway,
+} from "./lib/gatewayDiscovery";
 
 // SSH connections are handled via WebSocket TCP bridge
 // The browser runs SSH client (using @microsoft/dev-tunnels-ssh)
@@ -1557,10 +1564,45 @@ export async function registerRoutes(
   // ============================================
 
   // GET /api/admin/gateway-configs - List all gateway configs
+  // Live gateways as the enabled signal servers report them, limited to this
+  // deployment's TideCloak issuer. Shared with the discovery listing below so
+  // self-registered gateways show up without anyone adding them by hand.
+  async function fetchLiveGateways(): Promise<LiveGateway[]> {
+    const ownIssuer = `${getAuthServerUrl().replace(/\/+$/, "")}/realms/${getRealm()}`;
+    const enabled = await signalServerStorage.getEnabledSignalServers();
+    const results: LiveGateway[] = [];
+
+    await Promise.all(
+      enabled.map(async (ss) => {
+        try {
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), 5000);
+          const url = ss.url.replace(/\/$/, "") + "/api/gateways?issuer=" + encodeURIComponent(ownIssuer);
+          const resp = await fetch(url, { signal: controller.signal });
+          clearTimeout(timeout);
+          if (!resp.ok) return;
+          const data = (await resp.json()) as { gateways?: LiveGateway[] };
+          for (const gw of data.gateways ?? []) {
+            const issuer = gw.issuer;
+            // Same tolerance as the dashboard: a gateway too old to report an
+            // issuer is shown rather than hidden mid-rollout.
+            if (issuer && issuer.replace(/\/+$/, "").toLowerCase() !== ownIssuer.toLowerCase()) continue;
+            results.push({ ...gw, signalServerId: ss.id, signalServerName: ss.name, signalServerUrl: ss.url });
+          }
+        } catch {
+          // Signal server unreachable — its gateways simply aren't listed.
+          log(`[gateway-discovery] signal server ${ss.name} unreachable`);
+        }
+      })
+    );
+    return results;
+  }
+
   app.get("/api/admin/gateway-configs", authenticate, requireAdminOrConfigDownload, async (_req: AuthenticatedRequest, res) => {
     try {
       const configs = await gatewayConfigStorage.list();
-      res.json(configs);
+      const live = await fetchLiveGateways();
+      res.json(mergeDiscovered(configs, live));
     } catch (error) {
       log(`Failed to list gateway configs: ${error}`);
       res.status(500).json({ message: "Failed to list gateway configs" });
@@ -1596,7 +1638,31 @@ export async function registerRoutes(
   // still saves — the push result rides along in the response for the console.
   app.put("/api/admin/gateway-configs/:id", authenticate, requireAdminOrConfigDownload, async (req: AuthenticatedRequest, res) => {
     try {
-      const config = await gatewayConfigStorage.update(req.params.id, req.body);
+      let config: GatewayConfig | undefined | null;
+
+      if (isDiscoveredId(req.params.id)) {
+        // Adoption: a self-registered gateway has no record until someone edits
+        // it. Seed from what the gateway reported, then apply the edit on top,
+        // so untouched settings keep the gateway's real values instead of blanks.
+        const gatewayId = gatewayIdFromDiscoveredId(req.params.id);
+        const live = (await fetchLiveGateways()).find(
+          (g) => g.id.toLowerCase() === gatewayId.toLowerCase()
+        );
+        if (!live) {
+          return res.status(404).json({ message: "Gateway is no longer registered" });
+        }
+        // Guard against two admins adopting the same gateway at once.
+        const existing = (await gatewayConfigStorage.list()).find(
+          (c) => c.gatewayId.toLowerCase() === gatewayId.toLowerCase()
+        );
+        config = existing
+          ? await gatewayConfigStorage.update(existing.id, req.body)
+          : await gatewayConfigStorage.create({ ...adoptionRecord(live), ...req.body });
+        log(`[gateway-discovery] adopted ${gatewayId}`);
+      } else {
+        config = await gatewayConfigStorage.update(req.params.id, req.body);
+      }
+
       if (!config) return res.status(404).json({ message: "Gateway config not found" });
 
       const signalServers = await signalServerStorage.getSignalServers();

--- a/signal-server-rs/src/http/routes.rs
+++ b/signal-server-rs/src/http/routes.rs
@@ -91,6 +91,7 @@ pub async fn gateways(
                     "online": true,
                     "issuer": gw.metadata.issuer,
                     "clientId": gw.metadata.client_id,
+                    "config": gw.metadata.config,
                 }))
             })
         })
@@ -232,6 +233,7 @@ mod tests {
             realm: None,
             issuer: issuer.map(|s| s.to_string()),
             client_id: None,
+            config: None,
             public_url: None,
         };
         st.registry.register_gateway(id.into(), vec![], tx, meta, None);
@@ -258,6 +260,7 @@ mod tests {
             realm: None,
             issuer: None,
             client_id: None,
+            config: None,
             public_url: None,
         };
         st.registry.register_gateway(id.into(), vec![], tx, meta, None);

--- a/signal-server-rs/src/registry/mod.rs
+++ b/signal-server-rs/src/registry/mod.rs
@@ -22,6 +22,10 @@ pub struct GatewayMetadata {
     pub issuer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_id: Option<String>,
+    /// The gateway's current editable settings, as it reported them. Relayed
+    /// verbatim so a console can list a self-registered gateway accurately.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub public_url: Option<String>,
 }
@@ -244,6 +248,7 @@ mod tests {
             realm: None,
             issuer: None,
             client_id: None,
+            config: None,
             public_url: None,
         }
     }
@@ -266,6 +271,7 @@ mod tests {
             realm: Some("keylessh".into()),
             issuer: Some("https://tc.example.com/realms/keylessh".into()),
             client_id: Some("punchd".into()),
+            config: None,
             public_url: None,
         };
         r.register_gateway("gw-1".into(), vec!["1.2.3.4:443".into()], sender(), m, None);

--- a/signal-server-rs/src/signaling/handler.rs
+++ b/signal-server-rs/src/signaling/handler.rs
@@ -102,6 +102,7 @@ async fn handle_signaling(socket: WebSocket, client_ip: String, state: AppState)
                                 realm: parsed["metadata"]["realm"].as_str().map(|s| s.to_string()),
                                 issuer: parsed["metadata"]["issuer"].as_str().map(|s| s.trim_end_matches('/').to_string()),
                                 client_id: parsed["metadata"]["clientId"].as_str().map(|s| s.to_string()),
+                                config: parsed["metadata"].get("config").filter(|v| v.is_object()).cloned(),
                                 public_url: parsed["metadata"]["publicUrl"].as_str().map(|s| s.to_string()),
                             };
 
@@ -433,6 +434,7 @@ mod tests {
             realm: None,
             issuer: None,
             client_id: None,
+            config: None,
             public_url: None,
         }
     }

--- a/tests/server/gatewayDiscovery.test.ts
+++ b/tests/server/gatewayDiscovery.test.ts
@@ -1,0 +1,244 @@
+/**
+ * @fileoverview Tests for listing self-registered gateways and adopting them.
+ *
+ * The risk this guards against: adopting a gateway must never seed values the
+ * gateway did not report, because the first save pushes the record back and
+ * would overwrite a working config with blanks.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  mergeDiscovered,
+  toDiscovered,
+  adoptionRecord,
+  isDiscoveredId,
+  gatewayIdFromDiscoveredId,
+  signalServerFor,
+  DISCOVERED_PREFIX,
+  type LiveGateway,
+} from "../../server/lib/gatewayDiscovery";
+import type { GatewayConfig } from "../../server/storage";
+import type { SignalServer } from "@shared/schema";
+
+function stored(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    id: "cfg-1",
+    gatewayId: "Managed-GW",
+    displayName: "Managed",
+    stunServerUrl: "wss://signal.example.com",
+    apiSecret: null,
+    iceServers: null,
+    turnServer: null,
+    turnSecret: null,
+    backends: "App=http://10.0.0.5:8080",
+    tidecloakConfigB64: null,
+    authServerPublicUrl: null,
+    serverUrl: null,
+    vpnEnabled: false,
+    vpnSubnet: "10.66.0.0/24",
+    listenPort: 7891,
+    healthPort: 7892,
+    https: true,
+    tlsHostname: "localhost",
+    extraConfig: null,
+    directUrl: null,
+    enabled: true,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function live(overrides: Partial<LiveGateway> = {}): LiveGateway {
+  return {
+    id: "Self-GW",
+    displayName: "Self Registered",
+    online: true,
+    issuer: "https://tc.example.com/realms/demo",
+    signalServerId: "ss-1",
+    signalServerName: "Shared Signal",
+    signalServerUrl: "https://signal.example.com",
+    config: {
+      backends: "Shell=ssh://10.0.0.3:22",
+      listen_port: 7891,
+      health_port: 7892,
+      quic_port: 7893,
+      https: true,
+      tls_hostname: "gw.internal",
+      display_name: "Self Registered",
+      server_url: "https://console.example.com",
+      ice_servers: "stun:1.2.3.4:3478",
+      turn_server: "turn:1.2.3.4:3478",
+    },
+    ...overrides,
+  };
+}
+
+describe("mergeDiscovered", () => {
+  it("lists stored configs alongside gateways that have no record", () => {
+    const listed = mergeDiscovered([stored()], [live()]);
+
+    expect(listed).toHaveLength(2);
+    expect(listed[0]).toMatchObject({ gatewayId: "Managed-GW" });
+    expect(listed[1]).toMatchObject({ gatewayId: "Self-GW", discovered: true });
+  });
+
+  it("does not list a gateway that already has a record", () => {
+    const listed = mergeDiscovered([stored({ gatewayId: "Self-GW" })], [live()]);
+
+    expect(listed).toHaveLength(1);
+    expect((listed[0] as any).discovered).toBeUndefined();
+  });
+
+  it("matches an existing record case-insensitively", () => {
+    const listed = mergeDiscovered([stored({ gatewayId: "self-gw" })], [live({ id: "SELF-GW" })]);
+
+    expect(listed).toHaveLength(1);
+  });
+
+  it("lists a gateway once even when two signal servers report it", () => {
+    const listed = mergeDiscovered([], [live(), live({ signalServerId: "ss-2" })]);
+
+    expect(listed).toHaveLength(1);
+  });
+
+  it("returns stored configs unchanged when nothing is live", () => {
+    expect(mergeDiscovered([stored()], [])).toEqual([stored()]);
+  });
+
+  it("returns nothing when there is neither", () => {
+    expect(mergeDiscovered([], [])).toEqual([]);
+  });
+});
+
+describe("toDiscovered", () => {
+  it("surfaces the settings the gateway reported", () => {
+    const d = toDiscovered(live());
+
+    expect(d).toMatchObject({
+      id: `${DISCOVERED_PREFIX}Self-GW`,
+      gatewayId: "Self-GW",
+      discovered: true,
+      online: true,
+      backends: "Shell=ssh://10.0.0.3:22",
+      listenPort: 7891,
+      https: true,
+      tlsHostname: "gw.internal",
+      serverUrl: "https://console.example.com",
+      stunServerUrl: "https://signal.example.com",
+    });
+  });
+
+  it("leaves settings null when the gateway reported nothing", () => {
+    const d = toDiscovered(live({ config: null }));
+
+    expect(d.backends).toBeNull();
+    expect(d.listenPort).toBeNull();
+    expect(d.https).toBeNull();
+    expect(d.gatewayId).toBe("Self-GW");
+  });
+
+  it("ignores values of the wrong type rather than trusting them", () => {
+    const d = toDiscovered(live({
+      config: { listen_port: "7891", https: "yes", backends: 42, tls_hostname: "" },
+    }));
+
+    expect(d.listenPort).toBeNull();
+    expect(d.https).toBeNull();
+    expect(d.backends).toBeNull();
+    expect(d.tlsHostname).toBeNull();
+  });
+
+  it("rejects out-of-range ports", () => {
+    expect(toDiscovered(live({ config: { listen_port: 0 } })).listenPort).toBeNull();
+    expect(toDiscovered(live({ config: { listen_port: 70000 } })).listenPort).toBeNull();
+    expect(toDiscovered(live({ config: { listen_port: 1.5 } })).listenPort).toBeNull();
+  });
+
+  it("prefers the reported display name over the registration one", () => {
+    const d = toDiscovered(live({ displayName: "Registration", config: { display_name: "Reported" } }));
+    expect(d.displayName).toBe("Reported");
+  });
+
+  it("treats an explicitly offline gateway as offline", () => {
+    expect(toDiscovered(live({ online: false })).online).toBe(false);
+  });
+});
+
+describe("adoptionRecord", () => {
+  it("seeds a record from what the gateway reported", () => {
+    const record = adoptionRecord(live());
+
+    expect(record).toMatchObject({
+      gatewayId: "Self-GW",
+      backends: "Shell=ssh://10.0.0.3:22",
+      listenPort: 7891,
+      healthPort: 7892,
+      https: true,
+      tlsHostname: "gw.internal",
+      serverUrl: "https://console.example.com",
+      stunServerUrl: "https://signal.example.com",
+    });
+  });
+
+  it("omits anything the gateway did not report, rather than seeding blanks", () => {
+    // The important one: a seeded blank would be pushed back on first save and
+    // wipe the setting on a working gateway.
+    const record = adoptionRecord(live({ config: { backends: "App=http://h:80" } }));
+
+    expect(record.backends).toBe("App=http://h:80");
+    for (const field of ["listenPort", "healthPort", "https", "tlsHostname", "serverUrl", "iceServers", "turnServer"]) {
+      expect(record).not.toHaveProperty(field);
+    }
+  });
+
+  it("never carries secrets or the trust anchor", () => {
+    // Those are not reported by the gateway; assert the record can't grow them.
+    const record = adoptionRecord(live({
+      config: {
+        backends: "App=http://h:80",
+        api_secret: "leaked",
+        turn_secret: "leaked",
+        tidecloak_config_b64: "leaked",
+      } as Record<string, unknown>,
+    }));
+
+    expect(JSON.stringify(record)).not.toContain("leaked");
+    for (const field of ["apiSecret", "turnSecret", "tidecloakConfigB64", "authServerPublicUrl"]) {
+      expect(record).not.toHaveProperty(field);
+    }
+  });
+
+  it("always sets the gateway id, since that is what pushes are addressed to", () => {
+    expect(adoptionRecord(live({ config: null })).gatewayId).toBe("Self-GW");
+  });
+});
+
+describe("discovered ids", () => {
+  it("round-trips a gateway id", () => {
+    const id = toDiscovered(live()).id;
+    expect(isDiscoveredId(id)).toBe(true);
+    expect(gatewayIdFromDiscoveredId(id)).toBe("Self-GW");
+  });
+
+  it("does not mistake a stored record id for a discovered one", () => {
+    expect(isDiscoveredId("cfg-1")).toBe(false);
+    expect(isDiscoveredId("a7f3-discovered:x")).toBe(false);
+  });
+});
+
+describe("signalServerFor", () => {
+  const ss = { id: "ss-1", name: "Shared", url: "https://signal.example.com" } as SignalServer;
+
+  it("matches by id", () => {
+    expect(signalServerFor(live(), [ss])?.id).toBe("ss-1");
+  });
+
+  it("falls back to matching by url", () => {
+    expect(signalServerFor(live({ signalServerId: undefined }), [ss])?.id).toBe("ss-1");
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(signalServerFor(live({ signalServerId: "other", signalServerUrl: "https://other" }), [ss])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Two changes to how a Punchd gateway gets set up and managed. Both attack the same friction: a gateway you stand up is not manageable until you hand-carry config to it, or hand-retype config about it.

---

## 1. Self-registered gateways appear in the console

A gateway that registers with a signal server is live and usable, but `Punchd → Gateways` listed **only hand-created records** — so `proliant`, `Proliant2022` and `Sasha-Gateway` are running and invisible there. To manage one you had to retype what the gateway already knew.

Now live gateways are listed alongside stored ones, marked **Self-registered**, showing the settings they report. Editing one adopts it — creating the record — so there's no separate "add" step.

### The part that needed care

Seeding a record from signal server data alone would leave ports, TLS and server URL unknown, because the signal server never sees them. The first save would then push those **blanks over a working gateway's config**.

So the gateway reports its own editable settings at registration, and adoption seeds from that:

- It reports exactly the fields the console may push back — a test asserts that set never drifts from `PROTECTED_FIELDS`, so the console can't show a setting a push would silently refuse.
- It never reports `api_secret`, `turn_secret` or the TideCloak config. Those aren't pushable, and the signal server relaying this has no business holding them. Tested by asserting the serialized payload contains none of the secret values.
- `adoptionRecord` omits anything the gateway didn't report rather than defaulting it, so adoption can't invent a value a later push writes back.
- The edit is merged *over* the reported values, so untouched settings keep the gateway's real ones.
- Adoption re-checks for an existing record, in case two admins adopt the same gateway at once.

Discovered gateways are filtered by issuer like the dashboard, so they only show on their own tenant's console.

---

## 2. Installer wizard takes gateway.toml and tidecloak.json

The MSI installed the service and then *told you* to copy both files in yourself — the old exit page read "Copy your gateway.toml and tidecloak.json to C:\ProgramData\punchd-gateway then restart the service." Every fresh install needed a manual second step.

A **Configuration files** page now sits between Welcome and Install, with a Browse button for each:

- **Both optional** — cancelling a file dialog is a normal outcome, not an install failure.
- **Wrong-file detection** — each is checked for the fields that identify it (`gateway_id`; `realm` + `auth-server-url`), so picking the JSON in the TOML slot is caught with a pointer to where the right one comes from.
- **Unattended installs** keep working: `msiexec /i PunchdGateway.msi /qn GATEWAY_TOML_FILE="..." TIDECLOAK_JSON_FILE="..."`.
- Files land before `InstallFinalize`, so the service's first start sees its config.
- Uninstall removes only the two files it placed.

Custom actions follow the existing VPN installer's pattern; the CA compile step reuses the `vswhere` lookup rather than a hardcoded Visual Studio path.

---

## Testing

315 TypeScript tests (21 new on discovery/adoption) and 59 Rust tests (5 new on reported config) pass. `tsc --noEmit` shows only the errors already on main.

**The MSI is not verified.** WiX only runs on Windows — on Linux it prints `The WiX Toolset only supports Windows... All behavior after this point is undefined` and fails on path separators. I confirmed the XML parses and every cross-reference resolves (custom action IDs, `DoAction` targets, dialog navigation), and that the workflow YAML sequences the new MSVC step before `Build MSI`. **The C custom actions have never been compiled.** Worth a careful first install on a throwaway box.

## Depends on #52

`build-gateway-windows` currently fails on the vendored OpenSSL build before reaching any of this, so #52 has to merge first or the job still produces no MSI.
