### PR TITLE
Fix gateways hanging instead of reconnecting when the signal server restarts

### DIFF
--- a/bridges/punchd-bridge-rs/src/config.rs
+++ b/bridges/punchd-bridge-rs/src/config.rs
@@ -294,6 +294,32 @@ pub fn config_file_path() -> PathBuf {
     dir.join("gateway.toml")
 }
 
+// ── Log hygiene ─────────────────────────────────────────────────
+
+/// Strip credential-bearing query parameters before a URL reaches the logs.
+///
+/// Tunnel paths carry the user's access token. Logged verbatim it lands in a
+/// log file, decodable, complete with the user's roles and email.
+pub fn redact_query_secrets(url: &str) -> String {
+    const SECRET_PARAMS: &[&str] = &["token", "access_token", "secret", "api_secret", "password"];
+
+    let Some((base, query)) = url.split_once('?') else {
+        return url.to_string();
+    };
+
+    let redacted: Vec<String> = query
+        .split('&')
+        .map(|pair| match pair.split_once('=') {
+            Some((key, _)) if SECRET_PARAMS.contains(&key.to_ascii_lowercase().as_str()) => {
+                format!("{key}=<redacted>")
+            }
+            _ => pair.to_string(),
+        })
+        .collect();
+
+    format!("{base}?{}", redacted.join("&"))
+}
+
 // ── Self-reported config ────────────────────────────────────────
 
 /// Render backends back to the `Name=url;flags` form used in gateway.toml.
@@ -1042,6 +1068,33 @@ mod remote_config_tests {
             server_url: Some("https://console.example.com".into()),
             quic_port: 7893,
         }
+    }
+
+    #[test]
+    fn redacts_tokens_from_tunnel_paths() {
+        let path = "/ws/ssh?host=TideStun&port=22&token=eyJhbGciOiJFZERTQSJ9.payload.sig&serverId=X";
+        let out = redact_query_secrets(path);
+
+        assert!(!out.contains("eyJhbGciOiJFZERTQSJ9"), "token still present: {out}");
+        assert!(out.contains("token=<redacted>"));
+        // The parts that make the line worth logging survive.
+        assert!(out.contains("host=TideStun"));
+        assert!(out.contains("port=22"));
+        assert!(out.contains("serverId=X"));
+    }
+
+    #[test]
+    fn redaction_covers_every_secret_parameter_and_ignores_case() {
+        let out = redact_query_secrets("/p?api_secret=s1&PASSWORD=s2&Access_Token=s3&secret=s4");
+        for leaked in ["s1", "s2", "s3", "s4"] {
+            assert!(!out.contains(leaked), "{leaked} leaked: {out}");
+        }
+    }
+
+    #[test]
+    fn redaction_leaves_clean_urls_untouched() {
+        assert_eq!(redact_query_secrets("/ws/ssh"), "/ws/ssh");
+        assert_eq!(redact_query_secrets("/ws/ssh?host=x&port=22"), "/ws/ssh?host=x&port=22");
     }
 
     #[test]

--- a/bridges/punchd-bridge-rs/src/stun/stun_client.rs
+++ b/bridges/punchd-bridge-rs/src/stun/stun_client.rs
@@ -26,6 +26,16 @@ const MAX_RESPONSE_SIZE: usize = 50 * 1024 * 1024; // 50MB
 const MAX_SINGLE_WS: usize = 512 * 1024; // 512KB
 const CHUNK_SIZE: usize = 256 * 1024; // 256KB
 const PING_INTERVAL: Duration = Duration::from_secs(15);
+/// No frame of any kind for this long means the connection is dead.
+///
+/// Both ends ping every PING_INTERVAL, so silence for three intervals cannot
+/// happen on a healthy link. Without this the gateway can wait forever on a
+/// half-open socket — if the signal server disappears without a clean close
+/// reaching us, `next()` never returns, the reconnect loop is never re-entered,
+/// and the gateway stays silently unregistered until someone restarts it.
+const LIVENESS_TIMEOUT: Duration = Duration::from_secs(45);
+/// How often to test that deadline.
+const LIVENESS_CHECK: Duration = Duration::from_secs(5);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct StunRegistrationOptions {
@@ -426,9 +436,23 @@ async fn connect_and_run(
     });
 
     // Main message loop (QUIC endpoint + accept loop are managed by register())
+    let mut last_frame_at = tokio::time::Instant::now();
+    let mut liveness = tokio::time::interval(LIVENESS_CHECK);
+    liveness.tick().await; // the first tick completes immediately
+
     let result = loop {
         tokio::select! {
+            _ = liveness.tick() => {
+                if last_frame_at.elapsed() > LIVENESS_TIMEOUT {
+                    break ConnectionResult::Error(format!(
+                        "no traffic for {}s — treating the connection as dead",
+                        LIVENESS_TIMEOUT.as_secs()
+                    ));
+                }
+            }
             ws_msg = ws_stream.next() => {
+                // Any frame proves the link is alive, pings and pongs included.
+                last_frame_at = tokio::time::Instant::now();
                 match ws_msg {
                     Some(Ok(Message::Text(text))) => {
                         let parsed: serde_json::Value = match serde_json::from_str(&text) {

--- a/bridges/punchd-bridge-rs/src/webrtc/peer_handler.rs
+++ b/bridges/punchd-bridge-rs/src/webrtc/peer_handler.rs
@@ -1188,7 +1188,7 @@ async fn handle_ws_open(
         }
     }
 
-    tracing::info!("[WebRTC] WS tunnel opened: {} (id: {})", ws_path, ws_id);
+    tracing::info!("[WebRTC] WS tunnel opened: {} (id: {})", crate::config::redact_query_secrets(&ws_path), ws_id);
 
     let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel::<Vec<u8>>();
 

--- a/signal-server-rs/deploy.sh
+++ b/signal-server-rs/deploy.sh
@@ -174,8 +174,31 @@ if [ -n "${TIDECLOAK_CONFIG_B64:-}" ]; then
   export TIDECLOAK_CONFIG_B64
 fi
 
-nohup "$SIGNAL_BIN" > /tmp/signal-server-rs.log 2>&1 &
-echo $! > "$SIGNAL_PID_FILE"
+# Prefer systemd so the server comes back after a reboot or a crash. A bare
+# nohup process does not, and its absence shows up in the console as a
+# permissions error rather than an outage.
+UNIT_SRC="$(dirname "$0")/pkg/signal-server-rs.service"
+if command -v systemctl >/dev/null 2>&1 && [ -f "$UNIT_SRC" ]; then
+  echo "[Deploy] Installing systemd unit..."
+  sudo cp "$UNIT_SRC" /etc/systemd/system/signal-server-rs.service
+  sudo systemctl daemon-reload
+  sudo systemctl enable signal-server-rs >/dev/null 2>&1 || true
+
+  # Stop any nohup instance from an earlier deploy before systemd binds the port.
+  if [ -f "$SIGNAL_PID_FILE" ]; then
+    kill "$(cat "$SIGNAL_PID_FILE")" 2>/dev/null || true
+    rm -f "$SIGNAL_PID_FILE"
+  fi
+  pkill -f "release/signal-server-rs" 2>/dev/null || true
+
+  sudo systemctl restart signal-server-rs
+  USING_SYSTEMD=1
+else
+  echo "[Deploy] systemd unavailable — falling back to nohup (will not survive a reboot)"
+  nohup "$SIGNAL_BIN" > /tmp/signal-server-rs.log 2>&1 &
+  echo $! > "$SIGNAL_PID_FILE"
+  USING_SYSTEMD=0
+fi
 
 echo "[Deploy] Waiting for server to start..."
 sleep 3
@@ -191,7 +214,16 @@ else
   FAILED=1
 fi
 
-if kill -0 "$(cat "$SIGNAL_PID_FILE" 2>/dev/null)" 2>/dev/null; then
+if [ "${USING_SYSTEMD:-0}" = "1" ]; then
+  if systemctl is-active --quiet signal-server-rs; then
+    echo "[Deploy] signal-server-rs: running under systemd (restarts automatically)"
+    sudo journalctl -u signal-server-rs -n 5 --no-pager
+  else
+    echo "[Deploy] ERROR: signal-server-rs failed to start"
+    sudo journalctl -u signal-server-rs -n 20 --no-pager
+    FAILED=1
+  fi
+elif kill -0 "$(cat "$SIGNAL_PID_FILE" 2>/dev/null)" 2>/dev/null; then
   echo "[Deploy] signal-server-rs: running (PID $(cat "$SIGNAL_PID_FILE"))"
   tail -5 /tmp/signal-server-rs.log
 else

--- a/signal-server-rs/pkg/signal-server-rs.service
+++ b/signal-server-rs/pkg/signal-server-rs.service
@@ -1,0 +1,40 @@
+[Unit]
+Description=KeyleSSH Signal Server
+Documentation=https://github.com/sashyo/keylessh/blob/main/docs/SIGNAL-SERVER.md
+# coturn runs as a container and the server reads TURN settings at startup.
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=azureuser
+# Secrets live in the env file, so it is read by systemd rather than being
+# baked into this unit. Root-owned and unreadable by the service user is fine —
+# systemd reads it before dropping privileges.
+EnvironmentFile=/home/azureuser/keylessh/signal-server/.env
+Environment=PORT=9090
+ExecStart=/home/azureuser/keylessh/signal-server-rs/target/release/signal-server-rs
+
+# The whole point of this unit: a bare nohup process died on every reboot and
+# nothing brought it back, which surfaced in the console as "contact your
+# administrator to get server access".
+Restart=always
+RestartSec=5
+# Do not give up after repeated quick failures — a signal server that stays
+# down is worse than one that keeps retrying.
+StartLimitIntervalSec=0
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=signal-server-rs
+
+# Modest hardening. The server needs to bind 9090 and read its TLS certs;
+# it has no reason to write anywhere else.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=read-only
+ReadWritePaths=/tmp
+
+[Install]
+WantedBy=multi-user.target

--- a/signal-server-rs/src/proxy/ssh.rs
+++ b/signal-server-rs/src/proxy/ssh.rs
@@ -64,7 +64,7 @@ async fn handle_ssh_proxy(
     }
 
     let gw_ws_url = format!("ws://{}:{}/ws/ssh?{}", gw_ip, gw_port, query_string);
-    tracing::info!("[SSH-Proxy] Connecting to gateway: {gw_ws_url}");
+    tracing::info!("[SSH-Proxy] Connecting to gateway: {}", redact_query_secrets(&gw_ws_url));
 
     // Connect to gateway's /ws/ssh endpoint
     let gw_stream = match tokio_tungstenite::connect_async(&gw_ws_url).await {
@@ -113,4 +113,74 @@ async fn handle_ssh_proxy(
     }
 
     tracing::info!("[SSH-Proxy] Session ended for gateway {gw_id}");
+}
+
+/// Strip credential-bearing query parameters before a URL reaches the logs.
+///
+/// SSH tunnel URLs carry the user's access token. Logged verbatim it lands in a
+/// world-readable log file, decodable, complete with the user's roles and email.
+pub fn redact_query_secrets(url: &str) -> String {
+    const SECRET_PARAMS: &[&str] = &["token", "access_token", "secret", "api_secret", "password"];
+
+    let Some((base, query)) = url.split_once('?') else {
+        return url.to_string();
+    };
+
+    let redacted: Vec<String> = query
+        .split('&')
+        .map(|pair| match pair.split_once('=') {
+            Some((key, _)) if SECRET_PARAMS.contains(&key.to_ascii_lowercase().as_str()) => {
+                format!("{key}=<redacted>")
+            }
+            _ => pair.to_string(),
+        })
+        .collect();
+
+    format!("{base}?{}", redacted.join("&"))
+}
+
+#[cfg(test)]
+mod redaction_tests {
+    use super::redact_query_secrets;
+
+    #[test]
+    fn redacts_the_access_token() {
+        let url = "ws://gw:7891/ws/ssh?token=eyJhbGciOiJFZERTQSJ9.payload.sig&host=TideStun&port=22";
+        let out = redact_query_secrets(url);
+        assert!(!out.contains("eyJhbGciOiJFZERTQSJ9"), "token still present: {out}");
+        assert_eq!(out, "ws://gw:7891/ws/ssh?token=<redacted>&host=TideStun&port=22");
+    }
+
+    #[test]
+    fn keeps_the_parts_that_make_a_log_line_useful() {
+        let out = redact_query_secrets("ws://gw:7891/ws/ssh?token=abc&host=TideStun&port=22&serverId=X");
+        assert!(out.contains("host=TideStun"));
+        assert!(out.contains("port=22"));
+        assert!(out.contains("serverId=X"));
+    }
+
+    #[test]
+    fn redacts_every_known_secret_parameter() {
+        let out = redact_query_secrets("ws://h/p?api_secret=s1&password=s2&access_token=s3&secret=s4");
+        for leaked in ["s1", "s2", "s3", "s4"] {
+            assert!(!out.contains(leaked), "{leaked} leaked: {out}");
+        }
+    }
+
+    #[test]
+    fn is_case_insensitive_on_parameter_names() {
+        assert!(!redact_query_secrets("ws://h/p?TOKEN=secret").contains("secret"));
+    }
+
+    #[test]
+    fn leaves_urls_without_secrets_alone() {
+        assert_eq!(redact_query_secrets("ws://h/p"), "ws://h/p");
+        assert_eq!(redact_query_secrets("ws://h/p?host=x&port=22"), "ws://h/p?host=x&port=22");
+    }
+
+    #[test]
+    fn handles_malformed_query_pairs() {
+        let out = redact_query_secrets("ws://h/p?token&host=x&=y");
+        assert!(out.contains("host=x"));
+    }
 }


### PR DESCRIPTION
`Devops-GW` stopped serving today and needed a manual container restart, which produced `TCP connection timeout` in the browser.

## What happened

```
04:23:20  SSH session through Devops-GW to TideStun:22 — worked
04:23:31  WebRTC peer closed        ← last log line from the gateway
04:23:32  signal server restarted
          … 40 minutes of complete silence …
```

The container was `Running` the whole time with **0 restarts**. It simply stopped participating, and the signal server routed to its stale address.

The retry loop logs `Connecting to …` and `Reconnecting (delay: Nms)` on **every** attempt. Forty minutes produced none of those lines, so the loop was never re-entered — it was stuck inside `connect_and_run`.

## Cause

The main loop awaited `ws_stream.next()` with no deadline. If the peer disappears without a clean close reaching us — a half-open socket — that future never resolves. The loop never returns `Disconnected`, so the reconnect logic below it is unreachable.

There is a ping task, but when its send fails it only `break`s itself. It has no channel back to the main loop, so its death is silent.

The consequence is worse than one gateway: **any signal server restart can leave gateways permanently hung**, each needing a manual restart. Both of today's incidents fit that shape.

## Fix

A liveness deadline in the select loop. Any frame — pings and pongs included — marks the link alive; 45s of total silence (three ping intervals, impossible on a healthy link since both ends ping every 15s) ends the connection so the existing exponential backoff takes over.

## Two things that made it worse, also fixed

**The signal server had no supervisor.** `deploy.sh` launched it with `nohup`, so it dies on every reboot and stays dead — which is what took it down earlier today, and it surfaces in the console as "Contact your administrator to get server access" rather than as an outage. Now installs a systemd unit with `Restart=always` and `StartLimitIntervalSec=0`, falling back to `nohup` where systemd isn't available. It also kills any leftover nohup instance before starting, so the port isn't already taken.

**Access tokens were being written to the logs.** From the live log:

```
[SSH-Proxy] Connecting to gateway: ws://4.198.216.16:7891/ws/ssh?token=eyJhbGciOiJFZERTQSI…
```

A complete, decodable access token in a log file on disk, carrying the user's roles, email and vuid — once per SSH session. DPoP-binding limits replay but this should not be there at all. Credential-bearing query parameters are now redacted on both the signal server and the gateway, keeping `host`, `port` and `serverId` so the line stays useful.

## Testing

55 gateway tests and 34 signal server tests pass, 9 new on redaction (token stripped, every secret parameter, case-insensitive, clean URLs untouched, malformed pairs). `deploy.sh` passes `bash -n`.

**The hang fix itself is not covered by a test** — reproducing it needs a half-open socket, which is awkward to fake in a unit test. The reasoning is solid and the change is small, but the real confirmation is a deliberate signal server restart with a gateway attached: it should log `no traffic for 45s`, then `Reconnecting`, then re-register on its own. Worth doing on Staging-GW before trusting it everywhere.

The systemd unit has not been run — it needs `systemctl` on the actual host. Worth watching the first `deploy.sh` closely, particularly that `EnvironmentFile` parses the existing `.env` (it is `KEY=value` throughout, which systemd accepts, but values containing spaces or quotes would need review).
