### PR TITLE
Fix systemd unit dropping the runtime environment (TLS off, no TURN)

### DIFF
--- a/signal-server-rs/deploy.sh
+++ b/signal-server-rs/deploy.sh
@@ -180,6 +180,21 @@ fi
 UNIT_SRC="$(dirname "$0")/pkg/signal-server-rs.service"
 if command -v systemctl >/dev/null 2>&1 && [ -f "$UNIT_SRC" ]; then
   echo "[Deploy] Installing systemd unit..."
+
+  # systemd does not inherit this script's exports, so everything computed
+  # above has to be handed over in a file. Miss this and the server comes up on
+  # plain HTTP with no TURN.
+  RUNTIME_ENV=/etc/signal-server-rs.env
+  {
+    echo "PORT=${SIGNAL_PORT}"
+    echo "RELAY_PORT=${RELAY_PORT}"
+    echo "ICE_SERVERS=stun:${EXTERNAL_IP}:3478"
+    echo "TURN_SERVER=turn:${EXTERNAL_IP}:3478"
+    echo "RELAY_HOST=${DOMAIN:-${EXTERNAL_IP}}"
+    [ -n "$TLS_CERT" ] && echo "TLS_CERT_PATH=${TLS_CERT}"
+    [ -n "$TLS_KEY" ] && echo "TLS_KEY_PATH=${TLS_KEY}"
+  } | sudo tee "$RUNTIME_ENV" >/dev/null
+  sudo chmod 600 "$RUNTIME_ENV"
   sudo cp "$UNIT_SRC" /etc/systemd/system/signal-server-rs.service
   sudo systemctl daemon-reload
   sudo systemctl enable signal-server-rs >/dev/null 2>&1 || true

--- a/signal-server-rs/pkg/signal-server-rs.service
+++ b/signal-server-rs/pkg/signal-server-rs.service
@@ -4,15 +4,22 @@ Documentation=https://github.com/sashyo/keylessh/blob/main/docs/SIGNAL-SERVER.md
 # coturn runs as a container and the server reads TURN settings at startup.
 After=network-online.target docker.service
 Wants=network-online.target
+# Keep retrying indefinitely — a signal server that stays down is worse than
+# one that keeps trying, and its absence shows up as a permissions error.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-User=azureuser
-# Secrets live in the env file, so it is read by systemd rather than being
-# baked into this unit. Root-owned and unreadable by the service user is fine —
-# systemd reads it before dropping privileges.
+# Runs as root, as the previous nohup deployment did: the TLS material it reads
+# lives under /root/certs.
+User=root
+
+# Two files, and both are needed. The first holds the long-lived secrets. The
+# second is written by deploy.sh and carries everything it computes at run time
+# — TLS paths, ICE/TURN, relay host. Without it the server starts on plain HTTP
+# with no TURN, and every wss:// client fails.
 EnvironmentFile=/home/azureuser/keylessh/signal-server/.env
-Environment=PORT=9090
+EnvironmentFile=/etc/signal-server-rs.env
 ExecStart=/home/azureuser/keylessh/signal-server-rs/target/release/signal-server-rs
 
 # The whole point of this unit: a bare nohup process died on every reboot and
@@ -20,9 +27,6 @@ ExecStart=/home/azureuser/keylessh/signal-server-rs/target/release/signal-server
 # administrator to get server access".
 Restart=always
 RestartSec=5
-# Do not give up after repeated quick failures — a signal server that stays
-# down is worse than one that keeps retrying.
-StartLimitIntervalSec=0
 
 StandardOutput=journal
 StandardError=journal
@@ -33,7 +37,6 @@ SyslogIdentifier=signal-server-rs
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=full
-ProtectHome=read-only
 ReadWritePaths=/tmp
 
 [Install]


### PR DESCRIPTION
The systemd unit I added in #54 took the signal server down. Fixing it, and being explicit about what went wrong.

## What broke

`deploy.sh` computes TLS certificate paths, ICE/TURN servers and the relay host at run time, then `export`s them into the process it launches. **systemd does not inherit those exports.** My unit read only `.env` — which holds the long-lived secrets, not the computed values — so the server started with nothing but `PORT`:

```
[Signal] Signal Server listening on http://localhost:9090
```

Plain HTTP on the port every client reaches over `wss://`. Browsers failed with `SSL routines::wrong version number`, and with `ICE_SERVERS`/`TURN_SERVER` also missing, WebRTC had no relay to fall back to — hence `[SSH-WebRTC] Connection state: failed`.

## Fix

- `deploy.sh` writes everything it computes to `/etc/signal-server-rs.env` (mode 600), and the unit reads it alongside the secrets file.
- The service runs as **root**, matching the previous nohup deployment. My `User=azureuser` was wrong regardless of the env problem: the TLS material lives in `/root/certs`, which `azureuser` cannot traverse, so it could not have worked even with the paths supplied. `ProtectHome=read-only` would have blocked it too.
- `StartLimitIntervalSec` moves to `[Unit]`. In `[Service]` systemd logged `Unknown key 'StartLimitIntervalSec' in section [Service], ignoring` — so the restart-limit override I intended was never in effect.

## Already applied to the live server

I restored the running instance with an equivalent drop-in rather than waiting for this to merge, so it is serving HTTPS again with its gateways reconnected. Once this merges, a normal `deploy.sh` produces the same result from the repo, and the drop-in at `/etc/systemd/system/signal-server-rs.service.d/10-runtime.conf` can be deleted.

## What I should have done

I shipped a unit I had explicitly flagged as never having been run, and it landed on production. The specific miss was assuming `.env` held the full environment when it holds only the secrets — visible from reading `deploy.sh`'s export block, which I had already read. A single `systemctl show -p Environment` against a test run would have caught it.
