### PR TITLE
Scope the Punchd gateway list to this deployment, and split status from VPN

### DIFF
--- a/client/src/components/BackendsEditor.tsx
+++ b/client/src/components/BackendsEditor.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Plus, Trash2 } from "lucide-react";
+import {
+  parseBackends,
+  serializeBackends,
+  backendProtocol,
+  EMPTY_BACKEND,
+  type BackendRow,
+} from "@/lib/backends";
+
+/**
+ * Edit backends as rows instead of the `Name=url;flags` string the gateway
+ * stores.
+ *
+ * Rows are held here rather than derived from the string on each render. A row
+ * being filled in is not yet a valid backend, and the string cannot represent
+ * one — serializing drops it — so deriving would delete a new row the moment it
+ * was added. The string is still what gets saved: every edit serializes the
+ * complete rows back out through onChange.
+ */
+export function BackendsEditor({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (backends: string) => void;
+}) {
+  const [rows, setRows] = useState<BackendRow[]>(() => parseBackends(value));
+  const [raw, setRaw] = useState(false);
+
+  const commit = (next: BackendRow[]) => {
+    setRows(next);
+    onChange(serializeBackends(next));
+  };
+
+  const update = (index: number, patch: Partial<BackendRow>) =>
+    commit(rows.map((row, i) => (i === index ? { ...row, ...patch } : row)));
+
+  const add = () => commit([...rows, { ...EMPTY_BACKEND }]);
+  const remove = (index: number) => commit(rows.filter((_, i) => i !== index));
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">Backends <span className="text-muted-foreground font-normal">(optional)</span></Label>
+        <button
+          type="button"
+          onClick={() => {
+            if (raw) setRows(parseBackends(value)); // adopt whatever was typed
+            setRaw(!raw);
+          }}
+          className="text-[10px] text-muted-foreground hover:text-foreground underline underline-offset-2"
+        >
+          {raw ? "Edit as rows" : "Edit as text"}
+        </button>
+      </div>
+
+      {raw ? (
+        <Input
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="Name=rdp://host:3389;eddsa"
+          className="font-mono text-xs"
+        />
+      ) : (
+        <div className="space-y-2">
+          {rows.map((row, i) => (
+            <div key={i} className="rounded-md border border-border p-2 space-y-2">
+              <div className="flex gap-2">
+                <Input
+                  value={row.name}
+                  onChange={(e) => update(i, { name: e.target.value })}
+                  placeholder="Name"
+                  className="h-8 text-xs w-1/3"
+                />
+                <Input
+                  value={row.url}
+                  onChange={(e) => update(i, { url: e.target.value })}
+                  placeholder="ssh://10.0.0.9:22"
+                  className="h-8 text-xs flex-1 font-mono"
+                />
+                <Badge variant="outline" className="h-8 px-2 text-[10px] uppercase shrink-0 flex items-center">
+                  {backendProtocol(row.url)}
+                </Badge>
+                <Button type="button" size="icon" variant="ghost" className="h-8 w-8 shrink-0" onClick={() => remove(i)}>
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 pl-1">
+                {([
+                  ["eddsa", "EdDSA", "Passwordless RDP using EdDSA certificates"],
+                  ["noAuth", "No auth", "Skip JWT verification for this backend"],
+                  ["stripAuth", "Strip auth", "Remove auth headers before forwarding"],
+                ] as const).map(([key, label, title]) => (
+                  <label key={key} className="flex items-center gap-1.5 text-[11px] text-muted-foreground" title={title}>
+                    <input
+                      type="checkbox"
+                      checked={row[key]}
+                      onChange={(e) => update(i, { [key]: e.target.checked })}
+                      className="h-3 w-3 accent-[hsl(var(--neon-cyan))]"
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+
+          <Button type="button" variant="outline" size="sm" className="w-full gap-1.5 h-8 text-xs" onClick={add}>
+            <Plus className="h-3.5 w-3.5" /> Add backend
+          </Button>
+        </div>
+      )}
+
+      <p className="text-[10px] text-muted-foreground">
+        Pre-configured endpoints. Leave empty to use custom IP connections only.
+      </p>
+    </div>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -592,7 +592,9 @@ export interface DiscoveredGateway {
   turnServer: string | null;
 }
 
-export type ListedGateway = GatewayConfigSummary | DiscoveredGateway;
+// Stored records are annotated with whether the gateway is currently registered
+// — a record means configured, not connected.
+export type ListedGateway = (GatewayConfigSummary & { online?: boolean }) | DiscoveredGateway;
 
 export function isDiscovered(g: ListedGateway): g is DiscoveredGateway {
   return (g as DiscoveredGateway).discovered === true;

--- a/client/src/pages/AdminGateways.tsx
+++ b/client/src/pages/AdminGateways.tsx
@@ -20,13 +20,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { queryClient } from "@/lib/queryClient";
 import { api, isDiscovered, type GatewayConfigSummary, type GatewayPushResult, type ListedGateway } from "@/lib/api";
-import {
-  parseBackends,
-  serializeBackends,
-  backendProtocol,
-  EMPTY_BACKEND,
-  type BackendRow,
-} from "@/lib/backends";
+import { BackendsEditor } from "@/components/BackendsEditor";
 import { useAutoRefresh } from "@/hooks/useAutoRefresh";
 import { RefreshButton } from "@/components/RefreshButton";
 import {
@@ -78,100 +72,6 @@ function SshPublicKeyBanner() {
           </Button>
         </div>
       </div>
-    </div>
-  );
-}
-
-/**
- * Edit backends as rows instead of the `Name=url;flags` string the gateway
- * stores. The string stays the source of truth — rows are derived on each
- * render — so anything hand-written elsewhere still round-trips.
- */
-function BackendsEditor({ value, onChange }: { value: string; onChange: (backends: string) => void }) {
-  const rows = useMemo(() => parseBackends(value), [value]);
-  const [raw, setRaw] = useState(false);
-
-  const update = (index: number, patch: Partial<BackendRow>) => {
-    const next = rows.map((row, i) => (i === index ? { ...row, ...patch } : row));
-    onChange(serializeBackends(next));
-  };
-
-  const add = () => onChange(serializeBackends([...rows, { ...EMPTY_BACKEND, name: "", url: "http://" }]));
-  const remove = (index: number) => onChange(serializeBackends(rows.filter((_, i) => i !== index)));
-
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <Label className="text-xs">Backends <span className="text-muted-foreground font-normal">(optional)</span></Label>
-        <button
-          type="button"
-          onClick={() => setRaw(!raw)}
-          className="text-[10px] text-muted-foreground hover:text-foreground underline underline-offset-2"
-        >
-          {raw ? "Edit as rows" : "Edit as text"}
-        </button>
-      </div>
-
-      {raw ? (
-        <Input
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder="Name=rdp://host:3389;eddsa"
-          className="font-mono text-xs"
-        />
-      ) : (
-        <div className="space-y-2">
-          {rows.map((row, i) => (
-            <div key={i} className="rounded-md border border-border p-2 space-y-2">
-              <div className="flex gap-2">
-                <Input
-                  value={row.name}
-                  onChange={(e) => update(i, { name: e.target.value })}
-                  placeholder="Name"
-                  className="h-8 text-xs w-1/3"
-                />
-                <Input
-                  value={row.url}
-                  onChange={(e) => update(i, { url: e.target.value })}
-                  placeholder="rdp://10.0.0.9:3389"
-                  className="h-8 text-xs flex-1 font-mono"
-                />
-                <Badge variant="outline" className="h-8 px-2 text-[10px] uppercase shrink-0 flex items-center">
-                  {backendProtocol(row.url)}
-                </Badge>
-                <Button type="button" size="icon" variant="ghost" className="h-8 w-8 shrink-0" onClick={() => remove(i)}>
-                  <Trash2 className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 pl-1">
-                {([
-                  ["eddsa", "EdDSA", "Passwordless RDP using EdDSA certificates"],
-                  ["noAuth", "No auth", "Skip JWT verification for this backend"],
-                  ["stripAuth", "Strip auth", "Remove auth headers before forwarding"],
-                ] as const).map(([key, label, title]) => (
-                  <label key={key} className="flex items-center gap-1.5 text-[11px] text-muted-foreground" title={title}>
-                    <input
-                      type="checkbox"
-                      checked={row[key]}
-                      onChange={(e) => update(i, { [key]: e.target.checked })}
-                      className="h-3 w-3 accent-[hsl(var(--neon-cyan))]"
-                    />
-                    {label}
-                  </label>
-                ))}
-              </div>
-            </div>
-          ))}
-
-          <Button type="button" variant="outline" size="sm" className="w-full gap-1.5 h-8 text-xs" onClick={add}>
-            <Plus className="h-3.5 w-3.5" /> Add backend
-          </Button>
-        </div>
-      )}
-
-      <p className="text-[10px] text-muted-foreground">
-        Pre-configured endpoints. Leave empty to use custom IP connections only.
-      </p>
     </div>
   );
 }
@@ -365,6 +265,7 @@ export default function AdminGateways() {
       </div>
 
       <BackendsEditor
+        key={editing?.id ?? "new"}
         value={form.backends || ""}
         onChange={(backends) => setForm({ ...form, backends })}
       />

--- a/client/src/pages/AdminGateways.tsx
+++ b/client/src/pages/AdminGateways.tsx
@@ -491,7 +491,8 @@ export default function AdminGateways() {
                     <TableHead>Gateway</TableHead>
                     <TableHead className="hidden md:table-cell">STUN Server</TableHead>
                     <TableHead className="hidden lg:table-cell">Backends</TableHead>
-                    <TableHead>VPN</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="hidden sm:table-cell">VPN</TableHead>
                     <TableHead className="text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -527,10 +528,18 @@ export default function AdminGateways() {
                         <p className="text-xs text-muted-foreground truncate max-w-[200px]">{config.backends || "—"}</p>
                       </TableCell>
                       <TableCell>
-                        {isDiscovered(config) ? (
-                          <Badge variant="outline" className="text-muted-foreground">
-                            {config.online ? "Online" : "Offline"}
+                        {config.online ? (
+                          <Badge variant="outline" className="gap-1 bg-green-50 text-green-700 border-green-200 dark:bg-green-950/30 dark:text-green-400">
+                            <span className="h-1.5 w-1.5 rounded-full bg-current" /> Online
                           </Badge>
+                        ) : (
+                          <Badge variant="outline" className="text-muted-foreground">Offline</Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="hidden sm:table-cell">
+                        {isDiscovered(config) ? (
+                          // Not reported by the gateway, so it is unknown rather than off.
+                          <span className="text-xs text-muted-foreground">—</span>
                         ) : config.vpnEnabled ? (
                           <Badge variant="outline" className="gap-1 bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/30 dark:text-blue-400">
                             <Wifi className="h-3 w-3" /> On
@@ -580,7 +589,7 @@ export default function AdminGateways() {
                   ))}
                   {(!configs || configs.length === 0) && !isLoading && (
                     <TableRow>
-                      <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                      <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
                         No gateway configs. Click "Add Gateway" to create one.
                       </TableCell>
                     </TableRow>

--- a/client/src/pages/AdminGateways.tsx
+++ b/client/src/pages/AdminGateways.tsx
@@ -369,6 +369,21 @@ export default function AdminGateways() {
         onChange={(backends) => setForm({ ...form, backends })}
       />
 
+      {editing && isDiscovered(editing) && editing.issuer && (
+        <div className="rounded-md border border-border bg-muted/40 p-3 space-y-1">
+          <p className="text-xs font-medium flex items-center gap-1.5">
+            <Shield className="h-3.5 w-3.5 text-[hsl(var(--neon-cyan))]" />
+            This gateway trusts
+          </p>
+          <p className="text-[11px] font-mono break-all">{editing.issuer}</p>
+          <p className="text-[10px] text-muted-foreground">
+            Reported by the gateway. The tidecloak.json itself is never sent over the
+            wire and is not pushable — paste it below to let the console generate that
+            file for this gateway.
+          </p>
+        </div>
+      )}
+
       <div className="space-y-1">
         <Label className="text-xs">Punchd Client TideCloak Config</Label>
         <Textarea

--- a/server/lib/gatewayDiscovery.ts
+++ b/server/lib/gatewayDiscovery.ts
@@ -30,7 +30,7 @@ export interface LiveGateway {
 }
 
 /** A stored config, or a live gateway that has no record yet. */
-export type ListedGateway = (GatewayConfig & { discovered?: false }) | DiscoveredGateway;
+export type ListedGateway = (GatewayConfig & { discovered?: false; online?: boolean }) | DiscoveredGateway;
 
 export interface DiscoveredGateway {
   /** Synthetic id — no database row exists yet. */
@@ -129,6 +129,7 @@ export function mergeDiscovered(
   live: LiveGateway[]
 ): ListedGateway[] {
   const known = new Set(stored.map((c) => c.gatewayId.toLowerCase()));
+  const liveIds = new Set(live.filter((g) => g.online !== false).map((g) => g.id.toLowerCase()));
   const seen = new Set<string>();
   const discovered: DiscoveredGateway[] = [];
 
@@ -140,7 +141,11 @@ export function mergeDiscovered(
     discovered.push(toDiscovered(gw));
   }
 
-  return [...stored, ...discovered];
+  // A stored record says a gateway is configured, not that it is connected.
+  // Whether it is currently registered is what an admin actually wants to see.
+  const annotated = stored.map((c) => ({ ...c, online: liveIds.has(c.gatewayId.toLowerCase()) }));
+
+  return [...annotated, ...discovered];
 }
 
 /**

--- a/server/lib/gatewayDiscovery.ts
+++ b/server/lib/gatewayDiscovery.ts
@@ -53,6 +53,23 @@ export interface DiscoveredGateway {
   turnServer: string | null;
 }
 
+
+/**
+ * Whether a gateway belongs to this deployment.
+ *
+ * Strict: a gateway must report an issuer, and it must match. A gateway that
+ * reports none is not listed anywhere — during the rollout these were shown on
+ * every console, which is exactly the cross-tenant leakage the issuer is meant
+ * to prevent, so the tolerance ends once gateways are reporting.
+ *
+ * Comparison ignores a trailing slash and case, since the same realm can be
+ * written either way in a gateway's tidecloak.json.
+ */
+export function belongsToTenant(issuer: string | null | undefined, ownIssuer: string): boolean {
+  if (!issuer) return false;
+  return issuer.replace(/\/+$/, "").toLowerCase() === ownIssuer.replace(/\/+$/, "").toLowerCase();
+}
+
 /** Prefix marking an id as not-yet-adopted, so the UI and API can tell. */
 export const DISCOVERED_PREFIX = "discovered:";
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -145,6 +145,7 @@ import {
   adoptionRecord,
   isDiscoveredId,
   gatewayIdFromDiscoveredId,
+  belongsToTenant,
   type LiveGateway,
 } from "./lib/gatewayDiscovery";
 
@@ -1583,10 +1584,7 @@ export async function registerRoutes(
           if (!resp.ok) return;
           const data = (await resp.json()) as { gateways?: LiveGateway[] };
           for (const gw of data.gateways ?? []) {
-            const issuer = gw.issuer;
-            // Same tolerance as the dashboard: a gateway too old to report an
-            // issuer is shown rather than hidden mid-rollout.
-            if (issuer && issuer.replace(/\/+$/, "").toLowerCase() !== ownIssuer.toLowerCase()) continue;
+            if (!belongsToTenant(gw.issuer, ownIssuer)) continue;
             results.push({ ...gw, signalServerId: ss.id, signalServerName: ss.name, signalServerUrl: ss.url });
           }
         } catch {
@@ -1813,10 +1811,7 @@ export async function registerRoutes(
         // devops), so only list gateways that trust this instance's TideCloak
         // realm — gateways on another realm could never verify our tokens.
         const ownIssuer = `${getAuthServerUrl().replace(/\/+$/, "")}/realms/${getRealm()}`;
-        const sameTenant = (issuer?: string | null) =>
-          // Gateways predating issuer advertisement report nothing — keep them
-          // visible so an in-progress rollout doesn't blank the list.
-          !issuer || issuer.replace(/\/+$/, "").toLowerCase() === ownIssuer.toLowerCase();
+        const sameTenant = (issuer?: string | null) => belongsToTenant(issuer, ownIssuer);
 
         // Fetch gateways from each signal server in parallel (with timeout)
         const fetches = enabledServers.map(async (ss) => {

--- a/tests/client/backendsEditor.test.tsx
+++ b/tests/client/backendsEditor.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview Tests for the gateway backends row editor.
+ *
+ * The bug these exist for: rows used to be derived from the serialized string
+ * on every render. A half-filled row cannot be represented in that string —
+ * serializing drops it — so "Add backend" created a row that vanished before
+ * it could be rendered, and the button appeared to do nothing.
+ */
+
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BackendsEditor } from "../../client/src/components/BackendsEditor";
+
+function renderEditor(value = "") {
+  const onChange = vi.fn();
+  const utils = render(<BackendsEditor value={value} onChange={onChange} />);
+  return { onChange, ...utils };
+}
+
+describe("BackendsEditor", () => {
+  it("adds a visible row when Add backend is clicked", () => {
+    renderEditor("");
+    expect(screen.queryByPlaceholderText("Name")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /add backend/i }));
+
+    expect(screen.getByPlaceholderText("Name")).toBeTruthy();
+  });
+
+  it("keeps adding rows on repeated clicks", () => {
+    renderEditor("");
+    const add = screen.getByRole("button", { name: /add backend/i });
+
+    fireEvent.click(add);
+    fireEvent.click(add);
+    fireEvent.click(add);
+
+    expect(screen.getAllByPlaceholderText("Name")).toHaveLength(3);
+  });
+
+  it("keeps a half-filled row on screen", () => {
+    // Typing a name before a URL must not make the row disappear.
+    renderEditor("");
+    fireEvent.click(screen.getByRole("button", { name: /add backend/i }));
+    fireEvent.change(screen.getByPlaceholderText("Name"), { target: { value: "App" } });
+
+    expect((screen.getByPlaceholderText("Name") as HTMLInputElement).value).toBe("App");
+  });
+
+  it("reports the backend once both fields are filled", () => {
+    const { onChange } = renderEditor("");
+    fireEvent.click(screen.getByRole("button", { name: /add backend/i }));
+    fireEvent.change(screen.getByPlaceholderText("Name"), { target: { value: "App" } });
+    fireEvent.change(screen.getByPlaceholderText("ssh://10.0.0.9:22"), {
+      target: { value: "http://10.0.0.5:8080" },
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith("App=http://10.0.0.5:8080");
+  });
+
+  it("shows existing backends as rows", () => {
+    renderEditor("App=http://10.0.0.5:8080, Desk=rdp://10.0.0.9:3389;eddsa");
+
+    const names = screen.getAllByPlaceholderText("Name") as HTMLInputElement[];
+    expect(names.map((i) => i.value)).toEqual(["App", "Desk"]);
+  });
+
+  it("removes a row and reports the remainder", () => {
+    const { onChange } = renderEditor("App=http://h:80, Desk=rdp://h:3389");
+
+    // Each row has one delete button; the second row's is the second one.
+    const deletes = screen.getAllByRole("button").filter((b) => b.querySelector("svg.lucide-trash2"));
+    fireEvent.click(deletes[1]);
+
+    expect(onChange).toHaveBeenLastCalledWith("App=http://h:80");
+  });
+
+  it("reports a flag change", () => {
+    const { onChange } = renderEditor("Desk=rdp://h:3389");
+    fireEvent.click(screen.getByLabelText(/eddsa/i, { selector: "input" }));
+
+    expect(onChange).toHaveBeenLastCalledWith("Desk=rdp://h:3389;eddsa");
+  });
+});

--- a/tests/server/gatewayDiscovery.test.ts
+++ b/tests/server/gatewayDiscovery.test.ts
@@ -14,6 +14,7 @@ import {
   isDiscoveredId,
   gatewayIdFromDiscoveredId,
   signalServerFor,
+  belongsToTenant,
   DISCOVERED_PREFIX,
   type LiveGateway,
 } from "../../server/lib/gatewayDiscovery";
@@ -240,5 +241,34 @@ describe("signalServerFor", () => {
 
   it("returns undefined when nothing matches", () => {
     expect(signalServerFor(live({ signalServerId: "other", signalServerUrl: "https://other" }), [ss])).toBeUndefined();
+  });
+});
+
+describe("belongsToTenant", () => {
+  const own = "https://login.dauth.me/realms/keylessh-devops";
+
+  it("accepts an exact match", () => {
+    expect(belongsToTenant(own, own)).toBe(true);
+  });
+
+  it("rejects another realm on the same host", () => {
+    expect(belongsToTenant("https://login.dauth.me/realms/keylessh-demo", own)).toBe(false);
+  });
+
+  it("rejects the same realm name on another host", () => {
+    expect(belongsToTenant("https://staging.dauth.me/realms/keylessh-devops", own)).toBe(false);
+  });
+
+  it("ignores a trailing slash and case", () => {
+    expect(belongsToTenant(own + "/", own)).toBe(true);
+    expect(belongsToTenant("https://LOGIN.dauth.me/realms/keylessh-devops", own)).toBe(true);
+  });
+
+  it("rejects a gateway that reports no issuer", () => {
+    // Strict: reporting nothing used to mean "show everywhere", which is the
+    // cross-tenant leakage the issuer exists to prevent.
+    expect(belongsToTenant(null, own)).toBe(false);
+    expect(belongsToTenant(undefined, own)).toBe(false);
+    expect(belongsToTenant("", own)).toBe(false);
   });
 });

--- a/tests/server/gatewayDiscovery.test.ts
+++ b/tests/server/gatewayDiscovery.test.ts
@@ -103,8 +103,28 @@ describe("mergeDiscovered", () => {
     expect(listed).toHaveLength(1);
   });
 
-  it("returns stored configs unchanged when nothing is live", () => {
-    expect(mergeDiscovered([stored()], [])).toEqual([stored()]);
+  it("marks a stored gateway online when it is registered", () => {
+    // A record means configured; whether it is connected is a separate fact,
+    // and previously the two were conflated in the UI.
+    const listed = mergeDiscovered([stored({ gatewayId: "Self-GW" })], [live()]);
+
+    expect((listed[0] as any).online).toBe(true);
+  });
+
+  it("marks a stored gateway offline when it is not registered", () => {
+    const listed = mergeDiscovered([stored({ gatewayId: "Absent-GW" })], [live()]);
+
+    expect((listed[0] as any).online).toBe(false);
+  });
+
+  it("treats an explicitly offline live gateway as not registered", () => {
+    const listed = mergeDiscovered([stored({ gatewayId: "Self-GW" })], [live({ online: false })]);
+
+    expect((listed[0] as any).online).toBe(false);
+  });
+
+  it("returns stored configs when nothing is live, marked offline", () => {
+    expect(mergeDiscovered([stored()], [])).toEqual([{ ...stored(), online: false }]);
   });
 
   it("returns nothing when there is neither", () => {


### PR DESCRIPTION
Yes, that's right — the Punchd list should be scoped to the deployment exactly like the dashboard, and it wasn't quite.

## The tolerance had to go

Both surfaces treated "reports no issuer" as **show everywhere**. That was deliberate, so a staggered rollout wouldn't blank a console mid-upgrade — but it is precisely the cross-tenant leakage the issuer was introduced to stop. It's why devops still lists `Sasha-Gateway`, `gateway-vf28pg` and `gateway-z3pz71`.

Now strict on both: a gateway must report an issuer, and it must match this deployment's.

The rule also moves into a single shared `belongsToTenant`, replacing two near-identical copies that could drift — one in the dashboard aggregation, one in the admin discovery listing.

## What disappears

The four gateways still on old binaries report no issuer, so they vanish from **every** console until updated:

```
Demo-Gateway     keylessh-rdp        (being decommissioned)
Sasha-Gateway    DESKTOP-DFL00QK
gateway-vf28pg   proliant
gateway-z3pz71   Proliant2022
```

That's the intended trade — showing them on consoles they don't belong to was worse than showing them nowhere — but it does mean **the Proliant and desktop gateways drop off demo until their binaries are updated**. If you use them day to day, update those hosts before merging this.

The three container gateways all report issuers and are unaffected:

```
Devops-GW   → https://login.dauth.me/realms/keylessh-devops
Staging-GW  → https://staging.dauth.me/realms/keylessh-staging
Tide-GW     → https://login.dauth.me/realms/keylessh-demo
```

## tidecloak.json in Manage

The paste field was already there — it just looked empty, because a gateway never reports its TideCloak config and never can: that's the trust anchor, unpushable by design, and the signal server relaying gateway data has no business holding it.

What was missing is any way to see which TideCloak a self-registered gateway actually trusts. The Manage dialog now shows the reported issuer read-only, above the paste field, with a note explaining why the file itself isn't there. Paste one in and the console can generate `tidecloak.json` for that gateway as usual.

## Testing

26 discovery tests (5 new on the strict rule: exact match, different realm on the same host, same realm on a different host, trailing-slash and case tolerance, and the no-issuer rejection). Full suite green, `tsc` clean apart from the errors already on main.
